### PR TITLE
Change: People List Page Design

### DIFF
--- a/config/install/core.entity_form_display.node.ucb_people_list_page.default.yml
+++ b/config/install/core.entity_form_display.node.ucb_people_list_page.default.yml
@@ -4,16 +4,24 @@ dependencies:
   config:
     - field.field.node.ucb_people_list_page.body
     - field.field.node.ucb_people_list_page.field_ucb_people_department
+    - field.field.node.ucb_people_list_page.field_ucb_people_department_r
     - field.field.node.ucb_people_list_page.field_ucb_people_department_s
     - field.field.node.ucb_people_list_page.field_ucb_people_display
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_1
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_1_label
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_1_r
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_1_s
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_2
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_2_label
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_2_r
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_2_s
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_3
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_3_label
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_3_r
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_3_s
     - field.field.node.ucb_people_list_page.field_ucb_people_group_by
     - field.field.node.ucb_people_list_page.field_ucb_people_job_type
+    - field.field.node.ucb_people_list_page.field_ucb_people_job_type_r
     - field.field.node.ucb_people_list_page.field_ucb_people_job_type_s
     - field.field.node.ucb_people_list_page.field_ucb_people_order_by
     - node.type.ucb_people_list_page
@@ -23,65 +31,15 @@ dependencies:
     - text
 third_party_settings:
   field_group:
-    group_tabs:
-      children:
-        - group_display_format
-        - group_filter_group_order
-      label: Tabs
-      region: content
-      parent_name: ''
-      weight: 8
-      format_type: tabs
-      format_settings:
-        classes: ''
-        show_empty_fields: false
-        id: ''
-        direction: horizontal
-        width_breakpoint: 640
-    group_display_format:
-      children:
-        - field_ucb_people_display
-      label: Display/Format
-      region: content
-      parent_name: group_tabs
-      weight: 20
-      format_type: tab
-      format_settings:
-        classes: ''
-        show_empty_fields: false
-        id: ''
-        formatter: open
-        description: ''
-        required_fields: true
-    group_filter_group_order:
-      children:
-        - group_ucb_people_department
-        - group_ucb_people_job_type
-        - group_ucb_people_label_1
-        - group_ucb_people_label_2
-        - group_ucb_people_label_3
-        - field_ucb_people_group_by
-        - field_ucb_people_order_by
-      label: Filter/Group/Order
-      region: content
-      parent_name: group_tabs
-      weight: 21
-      format_type: tab
-      format_settings:
-        classes: ''
-        show_empty_fields: false
-        id: ''
-        formatter: closed
-        description: ''
-        required_fields: true
     group_ucb_people_department:
       children:
         - field_ucb_people_department
         - field_ucb_people_department_s
+        - group_ucb_people_department_uo
       label: Department
       region: content
-      parent_name: group_filter_group_order
-      weight: 12
+      parent_name: group_ucb_people_filters
+      weight: 23
       format_type: details
       format_settings:
         classes: ''
@@ -94,10 +52,11 @@ third_party_settings:
       children:
         - field_ucb_people_job_type
         - field_ucb_people_job_type_s
+        - group_ucb_people_job_type_uo
       label: 'Job Type'
       region: content
-      parent_name: group_filter_group_order
-      weight: 13
+      parent_name: group_ucb_people_filters
+      weight: 24
       format_type: details
       format_settings:
         classes: ''
@@ -110,42 +69,142 @@ third_party_settings:
       children:
         - field_ucb_people_filter_1
         - field_ucb_people_filter_1_s
-      label: 'Filter 1'
+        - group_ucb_people_filter_1_uo
+      label: 'Custom Filter 1'
       region: content
-      parent_name: group_filter_group_order
-      weight: 14
+      parent_name: group_ucb_people_filters
+      weight: 25
       format_type: details
       format_settings:
         classes: ''
         show_empty_fields: false
         id: ''
-        open: true
+        open: false
         description: ''
         required_fields: false
     group_ucb_people_label_2:
       children:
         - field_ucb_people_filter_2
         - field_ucb_people_filter_2_s
-      label: 'Filter 2'
+        - group_ucb_people_filter_2_uo
+      label: 'Custom Filter 2'
       region: content
-      parent_name: group_filter_group_order
-      weight: 15
+      parent_name: group_ucb_people_filters
+      weight: 26
       format_type: details
       format_settings:
         classes: ''
         show_empty_fields: false
         id: ''
-        open: true
+        open: false
         description: ''
         required_fields: false
     group_ucb_people_label_3:
       children:
         - field_ucb_people_filter_3
         - field_ucb_people_filter_3_s
-      label: 'Filter 3'
+        - group_ucb_people_filter_3_uo
+      label: 'Custom Filter 3'
       region: content
-      parent_name: group_filter_group_order
-      weight: 17
+      parent_name: group_ucb_people_filters
+      weight: 27
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: false
+        description: ''
+        required_fields: false
+    group_ucb_people_filter_2_uo:
+      children:
+        - field_ucb_people_filter_2_label
+        - field_ucb_people_filter_2_r
+      label: 'Visitor filtering options'
+      region: content
+      parent_name: group_ucb_people_label_2
+      weight: 18
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: false
+        description: ''
+        required_fields: false
+    group_ucb_people_filter_3_uo:
+      children:
+        - field_ucb_people_filter_3_label
+        - field_ucb_people_filter_3_r
+      label: 'Visitor filtering options'
+      region: content
+      parent_name: group_ucb_people_label_3
+      weight: 18
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: false
+        description: ''
+        required_fields: false
+    group_ucb_people_department_uo:
+      children:
+        - field_ucb_people_department_r
+      label: 'Visitor filtering options'
+      region: content
+      parent_name: group_ucb_people_department
+      weight: 19
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: false
+        description: ''
+        required_fields: false
+    group_ucb_people_job_type_uo:
+      children:
+        - field_ucb_people_job_type_r
+      label: 'Visitor filtering options'
+      region: content
+      parent_name: group_ucb_people_job_type
+      weight: 14
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: false
+        description: ''
+        required_fields: false
+    group_ucb_people_filter_1_uo:
+      children:
+        - field_ucb_people_filter_1_label
+        - field_ucb_people_filter_1_r
+      label: 'Visitor filtering options'
+      region: content
+      parent_name: group_ucb_people_label_1
+      weight: 25
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: false
+        description: ''
+        required_fields: false
+    group_ucb_people_filters:
+      children:
+        - group_ucb_people_department
+        - group_ucb_people_job_type
+        - group_ucb_people_label_1
+        - group_ucb_people_label_2
+        - group_ucb_people_label_3
+      label: Filters
+      region: content
+      parent_name: ''
+      weight: 11
       format_type: details
       format_settings:
         classes: ''
@@ -177,32 +236,54 @@ content:
     third_party_settings: {  }
   field_ucb_people_department:
     type: options_buttons
-    weight: 13
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_ucb_people_department_r:
+    type: boolean_checkbox
+    weight: 16
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_ucb_people_department_s:
     type: boolean_checkbox
-    weight: 14
+    weight: 18
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_ucb_people_display:
     type: options_select
-    weight: 9
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   field_ucb_people_filter_1:
     type: options_buttons
-    weight: 16
+    weight: 23
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_ucb_people_filter_1_label:
+    type: string_textfield
+    weight: 19
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_ucb_people_filter_1_r:
+    type: boolean_checkbox
+    weight: 21
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_ucb_people_filter_1_s:
     type: boolean_checkbox
-    weight: 17
+    weight: 24
     region: content
     settings:
       display_label: true
@@ -212,6 +293,21 @@ content:
     weight: 16
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_ucb_people_filter_2_label:
+    type: string_textfield
+    weight: 19
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_ucb_people_filter_2_r:
+    type: boolean_checkbox
+    weight: 21
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   field_ucb_people_filter_2_s:
     type: boolean_checkbox
@@ -226,6 +322,21 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_ucb_people_filter_3_label:
+    type: string_textfield
+    weight: 19
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_ucb_people_filter_3_r:
+    type: boolean_checkbox
+    weight: 20
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_ucb_people_filter_3_s:
     type: boolean_checkbox
     weight: 17
@@ -235,7 +346,7 @@ content:
     third_party_settings: {  }
   field_ucb_people_group_by:
     type: options_select
-    weight: 18
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -244,6 +355,13 @@ content:
     weight: 12
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_ucb_people_job_type_r:
+    type: boolean_checkbox
+    weight: 15
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   field_ucb_people_job_type_s:
     type: boolean_checkbox
@@ -254,7 +372,7 @@ content:
     third_party_settings: {  }
   field_ucb_people_order_by:
     type: options_select
-    weight: 19
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -272,7 +390,7 @@ content:
       display_label: true
     third_party_settings: {  }
   simple_sitemap:
-    weight: 10
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/install/core.entity_form_display.node.ucb_people_list_page.default.yml
+++ b/config/install/core.entity_form_display.node.ucb_people_list_page.default.yml
@@ -5,6 +5,9 @@ dependencies:
     - field.field.node.ucb_people_list_page.body
     - field.field.node.ucb_people_list_page.field_ucb_people_department
     - field.field.node.ucb_people_list_page.field_ucb_people_display
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_1
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_2
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_3
     - field.field.node.ucb_people_list_page.field_ucb_people_group_by
     - field.field.node.ucb_people_list_page.field_ucb_people_job_type
     - field.field.node.ucb_people_list_page.field_ucb_people_order_by
@@ -49,6 +52,9 @@ third_party_settings:
       children:
         - field_ucb_people_department
         - field_ucb_people_job_type
+        - field_ucb_people_filter_1
+        - field_ucb_people_filter_2
+        - field_ucb_people_filter_3
         - field_ucb_people_group_by
         - field_ucb_people_order_by
       label: Filter/Group/Order
@@ -96,9 +102,27 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_ucb_people_filter_1:
+    type: options_buttons
+    weight: 12
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_ucb_people_filter_2:
+    type: options_buttons
+    weight: 13
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_ucb_people_filter_3:
+    type: options_buttons
+    weight: 14
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_ucb_people_group_by:
     type: options_select
-    weight: 12
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -110,7 +134,7 @@ content:
     third_party_settings: {  }
   field_ucb_people_order_by:
     type: options_select
-    weight: 13
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -126,6 +150,11 @@ content:
     region: content
     settings:
       display_label: true
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox

--- a/config/install/core.entity_form_display.node.ucb_people_list_page.default.yml
+++ b/config/install/core.entity_form_display.node.ucb_people_list_page.default.yml
@@ -38,7 +38,7 @@ third_party_settings:
         - group_ucb_people_department_uo
       label: Department
       region: content
-      parent_name: group_ucb_people_filters
+      parent_name: group_ucb_people_tab_filters
       weight: 23
       format_type: details
       format_settings:
@@ -55,7 +55,7 @@ third_party_settings:
         - group_ucb_people_job_type_uo
       label: 'Job Type'
       region: content
-      parent_name: group_ucb_people_filters
+      parent_name: group_ucb_people_tab_filters
       weight: 24
       format_type: details
       format_settings:
@@ -72,14 +72,14 @@ third_party_settings:
         - group_ucb_people_filter_1_uo
       label: 'Custom Filter 1'
       region: content
-      parent_name: group_ucb_people_filters
+      parent_name: group_ucb_people_tab_filters
       weight: 25
       format_type: details
       format_settings:
         classes: ''
         show_empty_fields: false
         id: ''
-        open: false
+        open: true
         description: ''
         required_fields: false
     group_ucb_people_label_2:
@@ -89,14 +89,14 @@ third_party_settings:
         - group_ucb_people_filter_2_uo
       label: 'Custom Filter 2'
       region: content
-      parent_name: group_ucb_people_filters
+      parent_name: group_ucb_people_tab_filters
       weight: 26
       format_type: details
       format_settings:
         classes: ''
         show_empty_fields: false
         id: ''
-        open: false
+        open: true
         description: ''
         required_fields: false
     group_ucb_people_label_3:
@@ -106,14 +106,14 @@ third_party_settings:
         - group_ucb_people_filter_3_uo
       label: 'Custom Filter 3'
       region: content
-      parent_name: group_ucb_people_filters
+      parent_name: group_ucb_people_tab_filters
       weight: 27
       format_type: details
       format_settings:
         classes: ''
         show_empty_fields: false
         id: ''
-        open: false
+        open: true
         description: ''
         required_fields: false
     group_ucb_people_filter_2_uo:
@@ -194,7 +194,39 @@ third_party_settings:
         open: false
         description: ''
         required_fields: false
-    group_ucb_people_filters:
+    group_ucb_people_tabs:
+      children:
+        - group_ucb_people_tab_layout
+        - group_ucb_people_tab_filters
+      label: Tabs
+      region: content
+      parent_name: ''
+      weight: 8
+      format_type: tabs
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        direction: horizontal
+        width_breakpoint: 640
+    group_ucb_people_tab_layout:
+      children:
+        - field_ucb_people_display
+        - field_ucb_people_group_by
+        - field_ucb_people_order_by
+      label: Layout
+      region: content
+      parent_name: group_ucb_people_tabs
+      weight: 20
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: open
+        description: ''
+        required_fields: false
+    group_ucb_people_tab_filters:
       children:
         - group_ucb_people_department
         - group_ucb_people_job_type
@@ -203,14 +235,14 @@ third_party_settings:
         - group_ucb_people_label_3
       label: Filters
       region: content
-      parent_name: ''
-      weight: 11
-      format_type: details
+      parent_name: group_ucb_people_tabs
+      weight: 21
+      format_type: tab
       format_settings:
         classes: ''
         show_empty_fields: false
         id: ''
-        open: true
+        formatter: closed
         description: ''
         required_fields: false
 id: node.ucb_people_list_page.default
@@ -256,7 +288,7 @@ content:
     third_party_settings: {  }
   field_ucb_people_display:
     type: options_select
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -346,7 +378,7 @@ content:
     third_party_settings: {  }
   field_ucb_people_group_by:
     type: options_select
-    weight: 9
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -372,7 +404,7 @@ content:
     third_party_settings: {  }
   field_ucb_people_order_by:
     type: options_select
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/install/core.entity_form_display.node.ucb_people_list_page.default.yml
+++ b/config/install/core.entity_form_display.node.ucb_people_list_page.default.yml
@@ -4,12 +4,17 @@ dependencies:
   config:
     - field.field.node.ucb_people_list_page.body
     - field.field.node.ucb_people_list_page.field_ucb_people_department
+    - field.field.node.ucb_people_list_page.field_ucb_people_department_s
     - field.field.node.ucb_people_list_page.field_ucb_people_display
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_1
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_1_s
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_2
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_2_s
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_3
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_3_s
     - field.field.node.ucb_people_list_page.field_ucb_people_group_by
     - field.field.node.ucb_people_list_page.field_ucb_people_job_type
+    - field.field.node.ucb_people_list_page.field_ucb_people_job_type_s
     - field.field.node.ucb_people_list_page.field_ucb_people_order_by
     - node.type.ucb_people_list_page
   module:
@@ -50,11 +55,11 @@ third_party_settings:
         required_fields: true
     group_filter_group_order:
       children:
-        - field_ucb_people_department
-        - field_ucb_people_job_type
-        - field_ucb_people_filter_1
-        - field_ucb_people_filter_2
-        - field_ucb_people_filter_3
+        - group_ucb_people_department
+        - group_ucb_people_job_type
+        - group_ucb_people_label_1
+        - group_ucb_people_label_2
+        - group_ucb_people_label_3
         - field_ucb_people_group_by
         - field_ucb_people_order_by
       label: Filter/Group/Order
@@ -69,6 +74,86 @@ third_party_settings:
         formatter: closed
         description: ''
         required_fields: true
+    group_ucb_people_department:
+      children:
+        - field_ucb_people_department
+        - field_ucb_people_department_s
+      label: Department
+      region: content
+      parent_name: group_filter_group_order
+      weight: 12
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: true
+        description: ''
+        required_fields: false
+    group_ucb_people_job_type:
+      children:
+        - field_ucb_people_job_type
+        - field_ucb_people_job_type_s
+      label: 'Job Type'
+      region: content
+      parent_name: group_filter_group_order
+      weight: 13
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: true
+        description: ''
+        required_fields: false
+    group_ucb_people_label_1:
+      children:
+        - field_ucb_people_filter_1
+        - field_ucb_people_filter_1_s
+      label: 'Filter 1'
+      region: content
+      parent_name: group_filter_group_order
+      weight: 14
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: true
+        description: ''
+        required_fields: false
+    group_ucb_people_label_2:
+      children:
+        - field_ucb_people_filter_2
+        - field_ucb_people_filter_2_s
+      label: 'Filter 2'
+      region: content
+      parent_name: group_filter_group_order
+      weight: 15
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: true
+        description: ''
+        required_fields: false
+    group_ucb_people_label_3:
+      children:
+        - field_ucb_people_filter_3
+        - field_ucb_people_filter_3_s
+      label: 'Filter 3'
+      region: content
+      parent_name: group_filter_group_order
+      weight: 17
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: true
+        description: ''
+        required_fields: false
 id: node.ucb_people_list_page.default
 targetEntityType: node
 bundle: ucb_people_list_page
@@ -92,9 +177,16 @@ content:
     third_party_settings: {  }
   field_ucb_people_department:
     type: options_buttons
-    weight: 10
+    weight: 13
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_ucb_people_department_s:
+    type: boolean_checkbox
+    weight: 14
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   field_ucb_people_display:
     type: options_select
@@ -104,37 +196,65 @@ content:
     third_party_settings: {  }
   field_ucb_people_filter_1:
     type: options_buttons
-    weight: 12
+    weight: 16
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_ucb_people_filter_1_s:
+    type: boolean_checkbox
+    weight: 17
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   field_ucb_people_filter_2:
     type: options_buttons
-    weight: 13
+    weight: 16
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_ucb_people_filter_2_s:
+    type: boolean_checkbox
+    weight: 17
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   field_ucb_people_filter_3:
     type: options_buttons
-    weight: 14
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_ucb_people_filter_3_s:
+    type: boolean_checkbox
+    weight: 17
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_ucb_people_group_by:
     type: options_select
-    weight: 15
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }
   field_ucb_people_job_type:
     type: options_buttons
-    weight: 11
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_ucb_people_job_type_s:
+    type: boolean_checkbox
+    weight: 13
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_ucb_people_order_by:
     type: options_select
-    weight: 16
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/install/core.entity_form_display.node.ucb_person.default.yml
+++ b/config/install/core.entity_form_display.node.ucb_person.default.yml
@@ -31,6 +31,7 @@ third_party_settings:
       children:
         - group_personal
         - group_contact
+        - group_ucb_person_description
         - group_other
       label: Tabs
       region: content
@@ -85,18 +86,33 @@ third_party_settings:
         required_fields: false
     group_other:
       children:
-        - body
         - field_ucb_person_filter_1
         - field_ucb_person_filter_2
         - field_ucb_person_filter_3
       label: Other
       region: content
       parent_name: group_tabs
-      weight: 3
+      weight: 4
       format_type: tab
       format_settings:
         classes: ''
         show_empty_fields: true
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: false
+    group_ucb_person_description:
+      children:
+        - field_ucb_person_summary
+        - body
+      label: Description
+      region: content
+      parent_name: group_tabs
+      weight: 3
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
         id: ''
         formatter: closed
         description: ''
@@ -108,7 +124,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 2
+    weight: 27
     region: content
     settings:
       rows: 9

--- a/config/install/core.entity_form_display.node.ucb_person.default.yml
+++ b/config/install/core.entity_form_display.node.ucb_person.default.yml
@@ -6,6 +6,9 @@ dependencies:
     - field.field.node.ucb_person.field_ucb_person_address
     - field.field.node.ucb_person.field_ucb_person_department
     - field.field.node.ucb_person.field_ucb_person_email
+    - field.field.node.ucb_person.field_ucb_person_filter_1
+    - field.field.node.ucb_person.field_ucb_person_filter_2
+    - field.field.node.ucb_person.field_ucb_person_filter_3
     - field.field.node.ucb_person.field_ucb_person_first_name
     - field.field.node.ucb_person.field_ucb_person_job_type
     - field.field.node.ucb_person.field_ucb_person_last_name
@@ -83,6 +86,9 @@ third_party_settings:
     group_other:
       children:
         - body
+        - field_ucb_person_filter_1
+        - field_ucb_person_filter_2
+        - field_ucb_person_filter_3
       label: Other
       region: content
       parent_name: group_tabs
@@ -135,6 +141,36 @@ content:
     settings:
       placeholder: ''
       size: 60
+    third_party_settings: {  }
+  field_ucb_person_filter_1:
+    type: entity_reference_autocomplete
+    weight: 3
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_ucb_person_filter_2:
+    type: entity_reference_autocomplete
+    weight: 4
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_ucb_person_filter_3:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_ucb_person_first_name:
     type: string_textfield
@@ -203,6 +239,11 @@ content:
   path:
     type: path
     weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/install/core.entity_view_display.node.ucb_people_list_page.default.yml
+++ b/config/install/core.entity_view_display.node.ucb_people_list_page.default.yml
@@ -4,16 +4,24 @@ dependencies:
   config:
     - field.field.node.ucb_people_list_page.body
     - field.field.node.ucb_people_list_page.field_ucb_people_department
+    - field.field.node.ucb_people_list_page.field_ucb_people_department_r
     - field.field.node.ucb_people_list_page.field_ucb_people_department_s
     - field.field.node.ucb_people_list_page.field_ucb_people_display
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_1
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_1_label
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_1_r
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_1_s
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_2
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_2_label
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_2_r
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_2_s
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_3
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_3_label
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_3_r
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_3_s
     - field.field.node.ucb_people_list_page.field_ucb_people_group_by
     - field.field.node.ucb_people_list_page.field_ucb_people_job_type
+    - field.field.node.ucb_people_list_page.field_ucb_people_job_type_r
     - field.field.node.ucb_people_list_page.field_ucb_people_job_type_s
     - field.field.node.ucb_people_list_page.field_ucb_people_order_by
     - node.type.ucb_people_list_page
@@ -40,6 +48,16 @@ content:
     third_party_settings: {  }
     weight: 103
     region: content
+  field_ucb_people_department_r:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 119
+    region: content
   field_ucb_people_department_s:
     type: boolean
     label: hidden
@@ -64,6 +82,24 @@ content:
     third_party_settings: {  }
     weight: 107
     region: content
+  field_ucb_people_filter_1_label:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 115
+    region: content
+  field_ucb_people_filter_1_r:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 120
+    region: content
   field_ucb_people_filter_1_s:
     type: boolean
     label: hidden
@@ -81,6 +117,24 @@ content:
     third_party_settings: {  }
     weight: 108
     region: content
+  field_ucb_people_filter_2_label:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 116
+    region: content
+  field_ucb_people_filter_2_r:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 121
+    region: content
   field_ucb_people_filter_2_s:
     type: boolean
     label: hidden
@@ -97,6 +151,24 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 109
+    region: content
+  field_ucb_people_filter_3_label:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 117
+    region: content
+  field_ucb_people_filter_3_r:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 122
     region: content
   field_ucb_people_filter_3_s:
     type: boolean
@@ -121,6 +193,16 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 105
+    region: content
+  field_ucb_people_job_type_r:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 118
     region: content
   field_ucb_people_job_type_s:
     type: boolean

--- a/config/install/core.entity_view_display.node.ucb_people_list_page.default.yml
+++ b/config/install/core.entity_view_display.node.ucb_people_list_page.default.yml
@@ -5,6 +5,9 @@ dependencies:
     - field.field.node.ucb_people_list_page.body
     - field.field.node.ucb_people_list_page.field_ucb_people_department
     - field.field.node.ucb_people_list_page.field_ucb_people_display
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_1
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_2
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_3
     - field.field.node.ucb_people_list_page.field_ucb_people_group_by
     - field.field.node.ucb_people_list_page.field_ucb_people_job_type
     - field.field.node.ucb_people_list_page.field_ucb_people_order_by
@@ -38,6 +41,30 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 102
+    region: content
+  field_ucb_people_filter_1:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 107
+    region: content
+  field_ucb_people_filter_2:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 108
+    region: content
+  field_ucb_people_filter_3:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 109
     region: content
   field_ucb_people_group_by:
     type: list_key

--- a/config/install/core.entity_view_display.node.ucb_people_list_page.default.yml
+++ b/config/install/core.entity_view_display.node.ucb_people_list_page.default.yml
@@ -50,7 +50,7 @@ content:
     region: content
   field_ucb_people_department_r:
     type: boolean
-    label: above
+    label: hidden
     settings:
       format: default
       format_custom_false: ''
@@ -84,7 +84,7 @@ content:
     region: content
   field_ucb_people_filter_1_label:
     type: string
-    label: above
+    label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
@@ -92,7 +92,7 @@ content:
     region: content
   field_ucb_people_filter_1_r:
     type: boolean
-    label: above
+    label: hidden
     settings:
       format: default
       format_custom_false: ''
@@ -119,7 +119,7 @@ content:
     region: content
   field_ucb_people_filter_2_label:
     type: string
-    label: above
+    label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
@@ -127,7 +127,7 @@ content:
     region: content
   field_ucb_people_filter_2_r:
     type: boolean
-    label: above
+    label: hidden
     settings:
       format: default
       format_custom_false: ''
@@ -154,7 +154,7 @@ content:
     region: content
   field_ucb_people_filter_3_label:
     type: string
-    label: above
+    label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
@@ -162,7 +162,7 @@ content:
     region: content
   field_ucb_people_filter_3_r:
     type: boolean
-    label: above
+    label: hidden
     settings:
       format: default
       format_custom_false: ''
@@ -196,7 +196,7 @@ content:
     region: content
   field_ucb_people_job_type_r:
     type: boolean
-    label: above
+    label: hidden
     settings:
       format: default
       format_custom_false: ''

--- a/config/install/core.entity_view_display.node.ucb_people_list_page.default.yml
+++ b/config/install/core.entity_view_display.node.ucb_people_list_page.default.yml
@@ -4,12 +4,17 @@ dependencies:
   config:
     - field.field.node.ucb_people_list_page.body
     - field.field.node.ucb_people_list_page.field_ucb_people_department
+    - field.field.node.ucb_people_list_page.field_ucb_people_department_s
     - field.field.node.ucb_people_list_page.field_ucb_people_display
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_1
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_1_s
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_2
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_2_s
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_3
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_3_s
     - field.field.node.ucb_people_list_page.field_ucb_people_group_by
     - field.field.node.ucb_people_list_page.field_ucb_people_job_type
+    - field.field.node.ucb_people_list_page.field_ucb_people_job_type_s
     - field.field.node.ucb_people_list_page.field_ucb_people_order_by
     - node.type.ucb_people_list_page
   module:
@@ -35,6 +40,16 @@ content:
     third_party_settings: {  }
     weight: 103
     region: content
+  field_ucb_people_department_s:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 110
+    region: content
   field_ucb_people_display:
     type: list_default
     label: hidden
@@ -50,6 +65,16 @@ content:
     third_party_settings: {  }
     weight: 107
     region: content
+  field_ucb_people_filter_1_s:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 112
+    region: content
   field_ucb_people_filter_2:
     type: entity_reference_label
     label: above
@@ -58,6 +83,16 @@ content:
     third_party_settings: {  }
     weight: 108
     region: content
+  field_ucb_people_filter_2_s:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 113
+    region: content
   field_ucb_people_filter_3:
     type: entity_reference_label
     label: above
@@ -65,6 +100,16 @@ content:
       link: true
     third_party_settings: {  }
     weight: 109
+    region: content
+  field_ucb_people_filter_3_s:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 114
     region: content
   field_ucb_people_group_by:
     type: list_key
@@ -79,6 +124,16 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 105
+    region: content
+  field_ucb_people_job_type_s:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 111
     region: content
   field_ucb_people_order_by:
     type: list_key

--- a/config/install/core.entity_view_display.node.ucb_people_list_page.default.yml
+++ b/config/install/core.entity_view_display.node.ucb_people_list_page.default.yml
@@ -42,7 +42,7 @@ content:
     region: content
   field_ucb_people_department_s:
     type: boolean
-    label: above
+    label: hidden
     settings:
       format: default
       format_custom_false: ''
@@ -51,23 +51,22 @@ content:
     weight: 110
     region: content
   field_ucb_people_display:
-    type: list_default
+    type: list_key
     label: hidden
     settings: {  }
     third_party_settings: {  }
     weight: 102
     region: content
   field_ucb_people_filter_1:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: true
+    type: entity_reference_entity_id
+    label: hidden
+    settings: {  }
     third_party_settings: {  }
     weight: 107
     region: content
   field_ucb_people_filter_1_s:
     type: boolean
-    label: above
+    label: hidden
     settings:
       format: default
       format_custom_false: ''
@@ -76,16 +75,15 @@ content:
     weight: 112
     region: content
   field_ucb_people_filter_2:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: true
+    type: entity_reference_entity_id
+    label: hidden
+    settings: {  }
     third_party_settings: {  }
     weight: 108
     region: content
   field_ucb_people_filter_2_s:
     type: boolean
-    label: above
+    label: hidden
     settings:
       format: default
       format_custom_false: ''
@@ -94,16 +92,15 @@ content:
     weight: 113
     region: content
   field_ucb_people_filter_3:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: true
+    type: entity_reference_entity_id
+    label: hidden
+    settings: {  }
     third_party_settings: {  }
     weight: 109
     region: content
   field_ucb_people_filter_3_s:
     type: boolean
-    label: above
+    label: hidden
     settings:
       format: default
       format_custom_false: ''
@@ -127,7 +124,7 @@ content:
     region: content
   field_ucb_people_job_type_s:
     type: boolean
-    label: above
+    label: hidden
     settings:
       format: default
       format_custom_false: ''

--- a/config/install/core.entity_view_display.node.ucb_people_list_page.teaser.yml
+++ b/config/install/core.entity_view_display.node.ucb_people_list_page.teaser.yml
@@ -5,12 +5,17 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.ucb_people_list_page.body
     - field.field.node.ucb_people_list_page.field_ucb_people_department
+    - field.field.node.ucb_people_list_page.field_ucb_people_department_s
     - field.field.node.ucb_people_list_page.field_ucb_people_display
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_1
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_1_s
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_2
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_2_s
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_3
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_3_s
     - field.field.node.ucb_people_list_page.field_ucb_people_group_by
     - field.field.node.ucb_people_list_page.field_ucb_people_job_type
+    - field.field.node.ucb_people_list_page.field_ucb_people_job_type_s
     - field.field.node.ucb_people_list_page.field_ucb_people_order_by
     - node.type.ucb_people_list_page
   module:
@@ -36,10 +41,15 @@ content:
     region: content
 hidden:
   field_ucb_people_department: true
+  field_ucb_people_department_s: true
   field_ucb_people_display: true
   field_ucb_people_filter_1: true
+  field_ucb_people_filter_1_s: true
   field_ucb_people_filter_2: true
+  field_ucb_people_filter_2_s: true
   field_ucb_people_filter_3: true
+  field_ucb_people_filter_3_s: true
   field_ucb_people_group_by: true
   field_ucb_people_job_type: true
+  field_ucb_people_job_type_s: true
   field_ucb_people_order_by: true

--- a/config/install/core.entity_view_display.node.ucb_people_list_page.teaser.yml
+++ b/config/install/core.entity_view_display.node.ucb_people_list_page.teaser.yml
@@ -6,6 +6,9 @@ dependencies:
     - field.field.node.ucb_people_list_page.body
     - field.field.node.ucb_people_list_page.field_ucb_people_department
     - field.field.node.ucb_people_list_page.field_ucb_people_display
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_1
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_2
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_3
     - field.field.node.ucb_people_list_page.field_ucb_people_group_by
     - field.field.node.ucb_people_list_page.field_ucb_people_job_type
     - field.field.node.ucb_people_list_page.field_ucb_people_order_by
@@ -34,6 +37,9 @@ content:
 hidden:
   field_ucb_people_department: true
   field_ucb_people_display: true
+  field_ucb_people_filter_1: true
+  field_ucb_people_filter_2: true
+  field_ucb_people_filter_3: true
   field_ucb_people_group_by: true
   field_ucb_people_job_type: true
   field_ucb_people_order_by: true

--- a/config/install/core.entity_view_display.node.ucb_people_list_page.teaser.yml
+++ b/config/install/core.entity_view_display.node.ucb_people_list_page.teaser.yml
@@ -5,16 +5,24 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.ucb_people_list_page.body
     - field.field.node.ucb_people_list_page.field_ucb_people_department
+    - field.field.node.ucb_people_list_page.field_ucb_people_department_r
     - field.field.node.ucb_people_list_page.field_ucb_people_department_s
     - field.field.node.ucb_people_list_page.field_ucb_people_display
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_1
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_1_label
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_1_r
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_1_s
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_2
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_2_label
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_2_r
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_2_s
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_3
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_3_label
+    - field.field.node.ucb_people_list_page.field_ucb_people_filter_3_r
     - field.field.node.ucb_people_list_page.field_ucb_people_filter_3_s
     - field.field.node.ucb_people_list_page.field_ucb_people_group_by
     - field.field.node.ucb_people_list_page.field_ucb_people_job_type
+    - field.field.node.ucb_people_list_page.field_ucb_people_job_type_r
     - field.field.node.ucb_people_list_page.field_ucb_people_job_type_s
     - field.field.node.ucb_people_list_page.field_ucb_people_order_by
     - node.type.ucb_people_list_page
@@ -41,15 +49,23 @@ content:
     region: content
 hidden:
   field_ucb_people_department: true
+  field_ucb_people_department_r: true
   field_ucb_people_department_s: true
   field_ucb_people_display: true
   field_ucb_people_filter_1: true
+  field_ucb_people_filter_1_label: true
+  field_ucb_people_filter_1_r: true
   field_ucb_people_filter_1_s: true
   field_ucb_people_filter_2: true
+  field_ucb_people_filter_2_label: true
+  field_ucb_people_filter_2_r: true
   field_ucb_people_filter_2_s: true
   field_ucb_people_filter_3: true
+  field_ucb_people_filter_3_label: true
+  field_ucb_people_filter_3_r: true
   field_ucb_people_filter_3_s: true
   field_ucb_people_group_by: true
   field_ucb_people_job_type: true
+  field_ucb_people_job_type_r: true
   field_ucb_people_job_type_s: true
   field_ucb_people_order_by: true

--- a/config/install/core.entity_view_display.node.ucb_person.default.yml
+++ b/config/install/core.entity_view_display.node.ucb_person.default.yml
@@ -6,6 +6,9 @@ dependencies:
     - field.field.node.ucb_person.field_ucb_person_address
     - field.field.node.ucb_person.field_ucb_person_department
     - field.field.node.ucb_person.field_ucb_person_email
+    - field.field.node.ucb_person.field_ucb_person_filter_1
+    - field.field.node.ucb_person.field_ucb_person_filter_2
+    - field.field.node.ucb_person.field_ucb_person_filter_3
     - field.field.node.ucb_person.field_ucb_person_first_name
     - field.field.node.ucb_person.field_ucb_person_job_type
     - field.field.node.ucb_person.field_ucb_person_last_name
@@ -53,6 +56,30 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 6
+    region: content
+  field_ucb_person_filter_1:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 14
+    region: content
+  field_ucb_person_filter_2:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 15
+    region: content
+  field_ucb_person_filter_3:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 16
     region: content
   field_ucb_person_first_name:
     type: string

--- a/config/install/core.entity_view_display.node.ucb_person.teaser.yml
+++ b/config/install/core.entity_view_display.node.ucb_person.teaser.yml
@@ -7,6 +7,9 @@ dependencies:
     - field.field.node.ucb_person.field_ucb_person_address
     - field.field.node.ucb_person.field_ucb_person_department
     - field.field.node.ucb_person.field_ucb_person_email
+    - field.field.node.ucb_person.field_ucb_person_filter_1
+    - field.field.node.ucb_person.field_ucb_person_filter_2
+    - field.field.node.ucb_person.field_ucb_person_filter_3
     - field.field.node.ucb_person.field_ucb_person_first_name
     - field.field.node.ucb_person.field_ucb_person_job_type
     - field.field.node.ucb_person.field_ucb_person_last_name
@@ -41,6 +44,9 @@ hidden:
   field_ucb_person_address: true
   field_ucb_person_department: true
   field_ucb_person_email: true
+  field_ucb_person_filter_1: true
+  field_ucb_person_filter_2: true
+  field_ucb_person_filter_3: true
   field_ucb_person_first_name: true
   field_ucb_person_job_type: true
   field_ucb_person_last_name: true

--- a/config/install/field.field.block_content.ucb_form.field_ucb_form_block.yml
+++ b/config/install/field.field.block_content.ucb_form.field_ucb_form_block.yml
@@ -4,7 +4,6 @@ dependencies:
   config:
     - block_content.type.ucb_form
     - field.storage.block_content.field_ucb_form_block
-    - webform.webform.contact
   module:
     - webform
 id: block_content.ucb_form.field_ucb_form_block

--- a/config/install/field.field.media.image.field_media_image.yml
+++ b/config/install/field.field.media.image.field_media_image.yml
@@ -34,5 +34,4 @@ settings:
     title: ''
     width: null
     height: null
-    label_display: '0'
 field_type: image

--- a/config/install/field.field.media.image.field_media_image.yml
+++ b/config/install/field.field.media.image.field_media_image.yml
@@ -34,4 +34,5 @@ settings:
     title: ''
     width: null
     height: null
+    label_display: '0'
 field_type: image

--- a/config/install/field.field.node.ucb_people_list_page.field_ucb_people_department_r.yml
+++ b/config/install/field.field.node.ucb_people_list_page.field_ucb_people_department_r.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_people_department_r
+    - node.type.ucb_people_list_page
+id: node.ucb_people_list_page.field_ucb_people_department_r
+field_name: field_ucb_people_department_r
+entity_type: node
+bundle: ucb_people_list_page
+label: 'Restrict choices to those selected'
+description: 'This limits the filtering options available to only those selected above. If none are selected it will be ignored.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/install/field.field.node.ucb_people_list_page.field_ucb_people_department_s.yml
+++ b/config/install/field.field.node.ucb_people_list_page.field_ucb_people_department_s.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_people_department_s
+    - node.type.ucb_people_list_page
+id: node.ucb_people_list_page.field_ucb_people_department_s
+field_name: field_ucb_people_department_s
+entity_type: node
+bundle: ucb_people_list_page
+label: 'Allow visitors to filter by Department'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_1.yml
+++ b/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_1.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_people_filter_1
+    - node.type.ucb_people_list_page
+    - taxonomy.vocabulary.filter_1
+id: node.ucb_people_list_page.field_ucb_people_filter_1
+field_name: field_ucb_people_filter_1
+entity_type: node
+bundle: ucb_people_list_page
+label: 'Filter 1'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      filter_1: filter_1
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_1_label.yml
+++ b/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_1_label.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_people_filter_1_label
+    - node.type.ucb_people_list_page
+id: node.ucb_people_list_page.field_ucb_people_filter_1_label
+field_name: field_ucb_people_filter_1_label
+entity_type: node
+bundle: ucb_people_list_page
+label: Label
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: 'Filter 1'
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_1_r.yml
+++ b/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_1_r.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_people_filter_1_r
+    - node.type.ucb_people_list_page
+id: node.ucb_people_list_page.field_ucb_people_filter_1_r
+field_name: field_ucb_people_filter_1_r
+entity_type: node
+bundle: ucb_people_list_page
+label: 'Restrict choices to those selected'
+description: 'This limits the filtering options available to only those selected above. If none are selected it will be ignored.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_1_s.yml
+++ b/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_1_s.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_people_filter_1_s
+    - node.type.ucb_people_list_page
+id: node.ucb_people_list_page.field_ucb_people_filter_1_s
+field_name: field_ucb_people_filter_1_s
+entity_type: node
+bundle: ucb_people_list_page
+label: 'Allow visitors to filter by Filter 1'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_2.yml
+++ b/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_2.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_people_filter_2
+    - node.type.ucb_people_list_page
+    - taxonomy.vocabulary.filter_2
+id: node.ucb_people_list_page.field_ucb_people_filter_2
+field_name: field_ucb_people_filter_2
+entity_type: node
+bundle: ucb_people_list_page
+label: 'Filter 2'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      filter_2: filter_2
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_2_label.yml
+++ b/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_2_label.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_people_filter_2_label
+    - node.type.ucb_people_list_page
+id: node.ucb_people_list_page.field_ucb_people_filter_2_label
+field_name: field_ucb_people_filter_2_label
+entity_type: node
+bundle: ucb_people_list_page
+label: Label
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: 'Filter 2'
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_2_r.yml
+++ b/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_2_r.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_people_filter_2_r
+    - node.type.ucb_people_list_page
+id: node.ucb_people_list_page.field_ucb_people_filter_2_r
+field_name: field_ucb_people_filter_2_r
+entity_type: node
+bundle: ucb_people_list_page
+label: 'Restrict choices to those selected'
+description: 'This limits the filtering options available to only those selected above. If none are selected it will be ignored.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_2_s.yml
+++ b/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_2_s.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_people_filter_2_s
+    - node.type.ucb_people_list_page
+id: node.ucb_people_list_page.field_ucb_people_filter_2_s
+field_name: field_ucb_people_filter_2_s
+entity_type: node
+bundle: ucb_people_list_page
+label: 'Allow visitors to filter by Filter 2'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_3.yml
+++ b/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_3.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_people_filter_3
+    - node.type.ucb_people_list_page
+    - taxonomy.vocabulary.filter_3
+id: node.ucb_people_list_page.field_ucb_people_filter_3
+field_name: field_ucb_people_filter_3
+entity_type: node
+bundle: ucb_people_list_page
+label: 'Filter 3'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      filter_3: filter_3
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_3_label.yml
+++ b/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_3_label.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_people_filter_3_label
+    - node.type.ucb_people_list_page
+id: node.ucb_people_list_page.field_ucb_people_filter_3_label
+field_name: field_ucb_people_filter_3_label
+entity_type: node
+bundle: ucb_people_list_page
+label: Label
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: 'Filter 3'
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_3_r.yml
+++ b/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_3_r.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_people_filter_3_r
+    - node.type.ucb_people_list_page
+id: node.ucb_people_list_page.field_ucb_people_filter_3_r
+field_name: field_ucb_people_filter_3_r
+entity_type: node
+bundle: ucb_people_list_page
+label: 'Restrict choices to those selected'
+description: 'This limits the filtering options available to only those selected above. If none are selected it will be ignored.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_3_s.yml
+++ b/config/install/field.field.node.ucb_people_list_page.field_ucb_people_filter_3_s.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_people_filter_3_s
+    - node.type.ucb_people_list_page
+id: node.ucb_people_list_page.field_ucb_people_filter_3_s
+field_name: field_ucb_people_filter_3_s
+entity_type: node
+bundle: ucb_people_list_page
+label: 'Allow visitors to filter by Filter 3'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/install/field.field.node.ucb_people_list_page.field_ucb_people_job_type_r.yml
+++ b/config/install/field.field.node.ucb_people_list_page.field_ucb_people_job_type_r.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_people_job_type_r
+    - node.type.ucb_people_list_page
+id: node.ucb_people_list_page.field_ucb_people_job_type_r
+field_name: field_ucb_people_job_type_r
+entity_type: node
+bundle: ucb_people_list_page
+label: 'Restrict choices to those selected'
+description: 'This limits the filtering options available to only those selected above. If none are selected it will be ignored.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/install/field.field.node.ucb_people_list_page.field_ucb_people_job_type_s.yml
+++ b/config/install/field.field.node.ucb_people_list_page.field_ucb_people_job_type_s.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_people_job_type_s
+    - node.type.ucb_people_list_page
+id: node.ucb_people_list_page.field_ucb_people_job_type_s
+field_name: field_ucb_people_job_type_s
+entity_type: node
+bundle: ucb_people_list_page
+label: 'Allow visitors to filter by Job Type'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/install/field.field.node.ucb_person.body.yml
+++ b/config/install/field.field.node.ucb_person.body.yml
@@ -10,13 +10,13 @@ id: node.ucb_person.body
 field_name: body
 entity_type: node
 bundle: ucb_person
-label: Body
+label: Bio
 description: ''
 required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  display_summary: false
+  display_summary: true
   required_summary: false
 field_type: text_with_summary

--- a/config/install/field.field.node.ucb_person.field_ucb_person_filter_1.yml
+++ b/config/install/field.field.node.ucb_person.field_ucb_person_filter_1.yml
@@ -9,7 +9,7 @@ id: node.ucb_person.field_ucb_person_filter_1
 field_name: field_ucb_person_filter_1
 entity_type: node
 bundle: ucb_person
-label: 'Filter 1'
+label: 'Custom Filter 1'
 description: ''
 required: false
 translatable: false

--- a/config/install/field.field.node.ucb_person.field_ucb_person_filter_1.yml
+++ b/config/install/field.field.node.ucb_person.field_ucb_person_filter_1.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_person_filter_1
+    - node.type.ucb_person
+    - taxonomy.vocabulary.filter_1
+id: node.ucb_person.field_ucb_person_filter_1
+field_name: field_ucb_person_filter_1
+entity_type: node
+bundle: ucb_person
+label: 'Filter 1'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      filter_1: filter_1
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.node.ucb_person.field_ucb_person_filter_2.yml
+++ b/config/install/field.field.node.ucb_person.field_ucb_person_filter_2.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_person_filter_2
+    - node.type.ucb_person
+    - taxonomy.vocabulary.filter_2
+id: node.ucb_person.field_ucb_person_filter_2
+field_name: field_ucb_person_filter_2
+entity_type: node
+bundle: ucb_person
+label: 'Filter 2'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      filter_2: filter_2
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.node.ucb_person.field_ucb_person_filter_2.yml
+++ b/config/install/field.field.node.ucb_person.field_ucb_person_filter_2.yml
@@ -9,7 +9,7 @@ id: node.ucb_person.field_ucb_person_filter_2
 field_name: field_ucb_person_filter_2
 entity_type: node
 bundle: ucb_person
-label: 'Filter 2'
+label: 'Custom Filter 2'
 description: ''
 required: false
 translatable: false

--- a/config/install/field.field.node.ucb_person.field_ucb_person_filter_3.yml
+++ b/config/install/field.field.node.ucb_person.field_ucb_person_filter_3.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_person_filter_3
+    - node.type.ucb_person
+    - taxonomy.vocabulary.filter_3
+id: node.ucb_person.field_ucb_person_filter_3
+field_name: field_ucb_person_filter_3
+entity_type: node
+bundle: ucb_person
+label: 'Filter 3'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      filter_3: filter_3
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.node.ucb_person.field_ucb_person_filter_3.yml
+++ b/config/install/field.field.node.ucb_person.field_ucb_person_filter_3.yml
@@ -9,7 +9,7 @@ id: node.ucb_person.field_ucb_person_filter_3
 field_name: field_ucb_person_filter_3
 entity_type: node
 bundle: ucb_person
-label: 'Filter 3'
+label: 'Custom Filter 3'
 description: ''
 required: false
 translatable: false

--- a/config/install/field.storage.node.field_ucb_people_department_r.yml
+++ b/config/install/field.storage.node.field_ucb_people_department_r.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_ucb_people_department_r
+field_name: field_ucb_people_department_r
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_ucb_people_department_s.yml
+++ b/config/install/field.storage.node.field_ucb_people_department_s.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_ucb_people_department_s
+field_name: field_ucb_people_department_s
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_ucb_people_filter_1.yml
+++ b/config/install/field.storage.node.field_ucb_people_filter_1.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_ucb_people_filter_1
+field_name: field_ucb_people_filter_1
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_ucb_people_filter_1_label.yml
+++ b/config/install/field.storage.node.field_ucb_people_filter_1_label.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_ucb_people_filter_1_label
+field_name: field_ucb_people_filter_1_label
+entity_type: node
+type: string
+settings:
+  max_length: 128
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_ucb_people_filter_1_r.yml
+++ b/config/install/field.storage.node.field_ucb_people_filter_1_r.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_ucb_people_filter_1_r
+field_name: field_ucb_people_filter_1_r
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_ucb_people_filter_1_s.yml
+++ b/config/install/field.storage.node.field_ucb_people_filter_1_s.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_ucb_people_filter_1_s
+field_name: field_ucb_people_filter_1_s
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_ucb_people_filter_2.yml
+++ b/config/install/field.storage.node.field_ucb_people_filter_2.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_ucb_people_filter_2
+field_name: field_ucb_people_filter_2
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_ucb_people_filter_2_label.yml
+++ b/config/install/field.storage.node.field_ucb_people_filter_2_label.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_ucb_people_filter_2_label
+field_name: field_ucb_people_filter_2_label
+entity_type: node
+type: string
+settings:
+  max_length: 128
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_ucb_people_filter_2_r.yml
+++ b/config/install/field.storage.node.field_ucb_people_filter_2_r.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_ucb_people_filter_2_r
+field_name: field_ucb_people_filter_2_r
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_ucb_people_filter_2_s.yml
+++ b/config/install/field.storage.node.field_ucb_people_filter_2_s.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_ucb_people_filter_2_s
+field_name: field_ucb_people_filter_2_s
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_ucb_people_filter_3.yml
+++ b/config/install/field.storage.node.field_ucb_people_filter_3.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_ucb_people_filter_3
+field_name: field_ucb_people_filter_3
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_ucb_people_filter_3_label.yml
+++ b/config/install/field.storage.node.field_ucb_people_filter_3_label.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_ucb_people_filter_3_label
+field_name: field_ucb_people_filter_3_label
+entity_type: node
+type: string
+settings:
+  max_length: 128
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_ucb_people_filter_3_r.yml
+++ b/config/install/field.storage.node.field_ucb_people_filter_3_r.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_ucb_people_filter_3_r
+field_name: field_ucb_people_filter_3_r
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_ucb_people_filter_3_s.yml
+++ b/config/install/field.storage.node.field_ucb_people_filter_3_s.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_ucb_people_filter_3_s
+field_name: field_ucb_people_filter_3_s
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_ucb_people_group_by.yml
+++ b/config/install/field.storage.node.field_ucb_people_group_by.yml
@@ -19,6 +19,15 @@ settings:
     -
       value: department
       label: Department
+    -
+      value: filter_1
+      label: 'Filter 1'
+    -
+      value: filter_2
+      label: 'Filter 2'
+    -
+      value: filter_3
+      label: 'Filter 3'
   allowed_values_function: ''
 module: options
 locked: false

--- a/config/install/field.storage.node.field_ucb_people_group_by.yml
+++ b/config/install/field.storage.node.field_ucb_people_group_by.yml
@@ -14,8 +14,8 @@ settings:
       value: none
       label: None
     -
-      value: type
-      label: Type
+      value: job_type
+      label: Job Type
     -
       value: department
       label: Department

--- a/config/install/field.storage.node.field_ucb_people_group_by.yml
+++ b/config/install/field.storage.node.field_ucb_people_group_by.yml
@@ -15,7 +15,7 @@ settings:
       label: None
     -
       value: job_type
-      label: Job Type
+      label: 'Job Type'
     -
       value: department
       label: Department

--- a/config/install/field.storage.node.field_ucb_people_job_type_r.yml
+++ b/config/install/field.storage.node.field_ucb_people_job_type_r.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_ucb_people_job_type_r
+field_name: field_ucb_people_job_type_r
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_ucb_people_job_type_s.yml
+++ b/config/install/field.storage.node.field_ucb_people_job_type_s.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_ucb_people_job_type_s
+field_name: field_ucb_people_job_type_s
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_ucb_people_order_by.yml
+++ b/config/install/field.storage.node.field_ucb_people_order_by.yml
@@ -15,7 +15,7 @@ settings:
       label: 'Last Name'
     -
       value: type
-      label: 'Type + Last Name'
+      label: 'Has Job Type, Last Name'
   allowed_values_function: ''
 module: options
 locked: false

--- a/config/install/field.storage.node.field_ucb_person_filter_1.yml
+++ b/config/install/field.storage.node.field_ucb_person_filter_1.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_ucb_person_filter_1
+field_name: field_ucb_person_filter_1
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_ucb_person_filter_2.yml
+++ b/config/install/field.storage.node.field_ucb_person_filter_2.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_ucb_person_filter_2
+field_name: field_ucb_person_filter_2
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_ucb_person_filter_3.yml
+++ b/config/install/field.storage.node.field_ucb_person_filter_3.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_ucb_person_filter_3
+field_name: field_ucb_person_filter_3
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/taxonomy.vocabulary.filter_1.yml
+++ b/config/install/taxonomy.vocabulary.filter_1.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Filter 1'
+vid: filter_1
+description: 'A filter which can be used to categorize and search for people.'
+weight: 0

--- a/config/install/taxonomy.vocabulary.filter_1.yml
+++ b/config/install/taxonomy.vocabulary.filter_1.yml
@@ -3,5 +3,5 @@ status: true
 dependencies: {  }
 name: 'Filter 1'
 vid: filter_1
-description: 'A filter which can be used to categorize and search for people.'
+description: 'A custom filter which can be used to categorize and search for people.'
 weight: 0

--- a/config/install/taxonomy.vocabulary.filter_2.yml
+++ b/config/install/taxonomy.vocabulary.filter_2.yml
@@ -3,5 +3,5 @@ status: true
 dependencies: {  }
 name: 'Filter 2'
 vid: filter_2
-description: 'A filter which can be used to categorize and search for people.'
+description: 'A custom filter which can be used to categorize and search for people.'
 weight: 0

--- a/config/install/taxonomy.vocabulary.filter_2.yml
+++ b/config/install/taxonomy.vocabulary.filter_2.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Filter 2'
+vid: filter_2
+description: 'A filter which can be used to categorize and search for people.'
+weight: 0

--- a/config/install/taxonomy.vocabulary.filter_3.yml
+++ b/config/install/taxonomy.vocabulary.filter_3.yml
@@ -3,5 +3,5 @@ status: true
 dependencies: {  }
 name: 'Filter 3'
 vid: filter_3
-description: 'A filter which can be used to categorize and search for people.'
+description: 'A custom filter which can be used to categorize and search for people.'
 weight: 0

--- a/config/install/taxonomy.vocabulary.filter_3.yml
+++ b/config/install/taxonomy.vocabulary.filter_3.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Filter 3'
+vid: filter_3
+description: 'A filter which can be used to categorize and search for people.'
+weight: 0


### PR DESCRIPTION
Resolves #120 - Enhances People List Page design

Authored by @TeddyBearX and @patrickbrown-io 

Includes: 
## tiamat-custom-entities ( branch : tiamat-theme#120 )
### Person page (tiamat-custom-entities):

-  Adds taxonomy terms for "Filter 1", "Filter 2", "Filter 3"
-  Adds fields for "Filter 1", "Filter 2", "Filter 3"
-  The bio field on the person page has a summary option they can use (or ignore if they want to leave it blank)

### People List Page (tiamat-custom-entities):

-  Adds fields for filtering by "Filter 1", "Filter 2", "Filter 3"
-  Adds toggles for enabling filters to be user-accessible
-  "Child Terms" option

##  tiamat-theme (branch : tiamat-120)
### People List Page
-  Refactored as web component
-  Fixed no photo bug
-  The list view displays name, photo, job title(s), department, email, and phone number. and summary of bio field.
-  JavaScript and CSS UI for user-accessible filters