### PR TITLE
Adds secondary and footer menus

### DIFF
--- a/config/install/node.type.basic_page.yml
+++ b/config/install/node.type.basic_page.yml
@@ -7,6 +7,8 @@ third_party_settings:
   menu_ui:
     available_menus:
       - main
+      - secondary
+      - footer
     parent: 'main:'
 name: 'Basic Page'
 type: basic_page

--- a/config/install/node.type.form_page.yml
+++ b/config/install/node.type.form_page.yml
@@ -7,6 +7,8 @@ third_party_settings:
   menu_ui:
     available_menus:
       - main
+      - secondary
+      - footer
     parent: 'main:'
 name: 'Form Page'
 type: form_page

--- a/config/install/node.type.how_to_page.yml
+++ b/config/install/node.type.how_to_page.yml
@@ -7,6 +7,8 @@ third_party_settings:
   menu_ui:
     available_menus:
       - main
+      - secondary
+      - footer
     parent: 'main:'
 name: 'How-To Page'
 type: how_to_page

--- a/config/install/node.type.newsletter.yml
+++ b/config/install/node.type.newsletter.yml
@@ -7,6 +7,8 @@ third_party_settings:
   menu_ui:
     available_menus:
       - main
+      - secondary
+      - footer
     parent: 'main:'
 name: Newsletter
 type: newsletter

--- a/config/install/node.type.ucb_article.yml
+++ b/config/install/node.type.ucb_article.yml
@@ -7,6 +7,8 @@ third_party_settings:
   menu_ui:
     available_menus:
       - main
+      - secondary
+      - footer
     parent: 'main:'
 name: Article
 type: ucb_article

--- a/config/install/node.type.ucb_article_list.yml
+++ b/config/install/node.type.ucb_article_list.yml
@@ -7,6 +7,8 @@ third_party_settings:
   menu_ui:
     available_menus:
       - main
+      - secondary
+      - footer
     parent: 'main:'
 name: 'Article List'
 type: ucb_article_list

--- a/config/install/node.type.ucb_people_list_page.yml
+++ b/config/install/node.type.ucb_people_list_page.yml
@@ -7,6 +7,8 @@ third_party_settings:
   menu_ui:
     available_menus:
       - main
+      - secondary
+      - footer
     parent: 'main:'
 name: 'People List Page'
 type: ucb_people_list_page

--- a/config/install/node.type.ucb_person.yml
+++ b/config/install/node.type.ucb_person.yml
@@ -7,6 +7,8 @@ third_party_settings:
   menu_ui:
     available_menus:
       - main
+      - secondary
+      - footer
     parent: 'main:'
 name: Person
 type: ucb_person


### PR DESCRIPTION
This update adds secondary and footer menus in the header and footer of the site. Like with the main navigation, links can be added when creating or editing a page. The secondary menu can be displayed either to the right of or above the main navigation, with the option to display action links as buttons.

CuBoulder/tiamat-theme#163

Sister PRs in:
- [tiamat-profile](https://github.com/CuBoulder/tiamat-profile/pull/22)
- [tiamat-theme](https://github.com/CuBoulder/tiamat-theme/pull/187)
- [ucb_site_configuration](https://github.com/CuBoulder/ucb_site_configuration/pull/5)