### PR TITLE
Adds Slate Form Block Type to Block Library

### DIFF
--- a/config/install/block_content.type.ucb_slate_form.yml
+++ b/config/install/block_content.type.ucb_slate_form.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: ucb_slate_form
+label: 'Slate Form'
+revision: 0
+description: 'Create a Slate Form Block'

--- a/config/install/core.entity_form_display.block_content.ucb_slate_form.default.yml
+++ b/config/install/core.entity_form_display.block_content.ucb_slate_form.default.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_slate_form
+    - field.field.block_content.ucb_slate_form.body
+    - field.field.block_content.ucb_slate_form.field_ucb_slate_form_domain
+    - field.field.block_content.ucb_slate_form.field_ucb_slate_form_id
+  module:
+    - link
+id: block_content.ucb_slate_form.default
+targetEntityType: block_content
+bundle: ucb_slate_form
+mode: default
+content:
+  field_ucb_slate_form_domain:
+    type: link_default
+    weight: 1
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  field_ucb_slate_form_id:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  body: true
+  info: true

--- a/config/install/core.entity_view_display.block_content.ucb_slate_form.default.yml
+++ b/config/install/core.entity_view_display.block_content.ucb_slate_form.default.yml
@@ -1,0 +1,44 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_slate_form
+    - field.field.block_content.ucb_slate_form.body
+    - field.field.block_content.ucb_slate_form.field_ucb_slate_form_domain
+    - field.field.block_content.ucb_slate_form.field_ucb_slate_form_id
+  module:
+    - link
+    - text
+id: block_content.ucb_slate_form.default
+targetEntityType: block_content
+bundle: ucb_slate_form
+mode: default
+content:
+  body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_ucb_slate_form_domain:
+    type: link
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_ucb_slate_form_id:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden: {  }

--- a/config/install/field.field.block_content.ucb_slate_form.body.yml
+++ b/config/install/field.field.block_content.ucb_slate_form.body.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_slate_form
+    - field.storage.block_content.body
+  module:
+    - text
+id: block_content.ucb_slate_form.body
+field_name: body
+entity_type: block_content
+bundle: ucb_slate_form
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+  required_summary: false
+field_type: text_with_summary

--- a/config/install/field.field.block_content.ucb_slate_form.field_ucb_slate_form_domain.yml
+++ b/config/install/field.field.block_content.ucb_slate_form.field_ucb_slate_form_domain.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_slate_form
+    - field.storage.block_content.field_ucb_slate_form_domain
+  module:
+    - link
+id: block_content.ucb_slate_form.field_ucb_slate_form_domain
+field_name: field_ucb_slate_form_domain
+entity_type: block_content
+bundle: ucb_slate_form
+label: 'Slate Form URL'
+description: 'Enter the domain of your Slate Form'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 0
+  link_type: 16
+field_type: link

--- a/config/install/field.field.block_content.ucb_slate_form.field_ucb_slate_form_id.yml
+++ b/config/install/field.field.block_content.ucb_slate_form.field_ucb_slate_form_id.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_slate_form
+    - field.storage.block_content.field_ucb_slate_form_id
+id: block_content.ucb_slate_form.field_ucb_slate_form_id
+field_name: field_ucb_slate_form_id
+entity_type: block_content
+bundle: ucb_slate_form
+label: 'Form ID'
+description: 'Enter the Slate Form ID'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/install/field.storage.block_content.field_ucb_slate_form_domain.yml
+++ b/config/install/field.storage.block_content.field_ucb_slate_form_domain.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - link
+id: block_content.field_ucb_slate_form_domain
+field_name: field_ucb_slate_form_domain
+entity_type: block_content
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_ucb_slate_form_id.yml
+++ b/config/install/field.storage.block_content.field_ucb_slate_form_id.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_ucb_slate_form_id
+field_name: field_ucb_slate_form_id
+entity_type: block_content
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
One of the third party services from [tiamat-theme/#165](https://github.com/CuBoulder/tiamat-theme/issues/165) - this enables a custom Slate Form block type to be placed. Provide a Slate Form ID and the Slate Domain to create a Slate form on your page.

Includes:
- tiamat-custom-entities => issue/165
- tiamat-theme => issue/165

---

The other third party services required from [tiamat-theme/#165](https://github.com/CuBoulder/tiamat-theme/issues/165) will need to be handled in https://github.com/CuBoulder/ucb_site_configuration as they require a different configuration process and more robust placement options