### PR TITLE
Creates a StatusPage service custom block type

### DIFF
--- a/config/install/block_content.type.statuspage_block.yml
+++ b/config/install/block_content.type.statuspage_block.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: statuspage_block
+label: 'Statuspage Block'
+revision: 0
+description: 'Creates a placeable block showing the current status of a Statuspage.io site'

--- a/config/install/core.entity_form_display.block_content.statuspage_block.default.yml
+++ b/config/install/core.entity_form_display.block_content.statuspage_block.default.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.statuspage_block
+    - field.field.block_content.statuspage_block.body
+    - field.field.block_content.statuspage_block.field_ucb_statuspage_id
+id: block_content.statuspage_block.default
+targetEntityType: block_content
+bundle: statuspage_block
+mode: default
+content:
+  field_ucb_statuspage_id:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  info:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  body: true

--- a/config/install/core.entity_view_display.block_content.statuspage_block.default.yml
+++ b/config/install/core.entity_view_display.block_content.statuspage_block.default.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.statuspage_block
+    - field.field.block_content.statuspage_block.body
+    - field.field.block_content.statuspage_block.field_ucb_statuspage_id
+  module:
+    - layout_builder
+    - text
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: block_content.statuspage_block.default
+targetEntityType: block_content
+bundle: statuspage_block
+mode: default
+content:
+  body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_ucb_statuspage_id:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  layout_builder__layout: true

--- a/config/install/field.field.block_content.statuspage_block.body.yml
+++ b/config/install/field.field.block_content.statuspage_block.body.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.statuspage_block
+    - field.storage.block_content.body
+  module:
+    - text
+id: block_content.statuspage_block.body
+field_name: body
+entity_type: block_content
+bundle: statuspage_block
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+  required_summary: false
+field_type: text_with_summary

--- a/config/install/field.field.block_content.statuspage_block.field_ucb_statuspage_id.yml
+++ b/config/install/field.field.block_content.statuspage_block.field_ucb_statuspage_id.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.statuspage_block
+    - field.storage.block_content.field_ucb_statuspage_id
+id: block_content.statuspage_block.field_ucb_statuspage_id
+field_name: field_ucb_statuspage_id
+entity_type: block_content
+bundle: statuspage_block
+label: 'Page ID'
+description: 'Provide your page ID for the third-party StatusPage.io service'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/install/field.storage.block_content.body.yml
+++ b/config/install/field.storage.block_content.body.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - text
+id: block_content.body
+field_name: body
+entity_type: block_content
+type: text_with_summary
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: true
+custom_storage: false

--- a/config/install/field.storage.block_content.field_ucb_statuspage_id.yml
+++ b/config/install/field.storage.block_content.field_ucb_statuspage_id.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_ucb_statuspage_id
+field_name: field_ucb_statuspage_id
+entity_type: block_content
+type: string
+settings:
+  max_length: 30
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
Allows for site editors to place a StatusPage.io service indictor block in Layout Builder - which shows the current status of a statuspage site at a glance.

Includes changes to:
- tiamat-theme (issue/193)
- tiamat-custom-entities (issue/193)

Resolves [#193](https://github.com/CuBoulder/tiamat-theme/issues/193)