### PR TITLE
Hidden Terms: Category and Tag Taxonomy Display Option

### DIFF
--- a/config/install/core.entity_form_display.taxonomy_term.category.default.yml
+++ b/config/install/core.entity_form_display.taxonomy_term.category.default.yml
@@ -1,0 +1,56 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.category.field_ucb_category_display
+    - taxonomy.vocabulary.category
+  module:
+    - path
+    - text
+id: taxonomy_term.category.default
+targetEntityType: taxonomy_term
+bundle: category
+mode: default
+content:
+  description:
+    type: text_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_ucb_category_display:
+    type: boolean_checkbox
+    weight: 101
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 100
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden: {  }

--- a/config/install/core.entity_form_display.taxonomy_term.category.default.yml
+++ b/config/install/core.entity_form_display.taxonomy_term.category.default.yml
@@ -13,23 +13,23 @@ bundle: category
 mode: default
 content:
   description:
-    type: text_textfield
-    weight: 0
+    type: text_textarea
+    weight: 1
     region: content
     settings:
-      size: 60
+      rows: 5
       placeholder: ''
     third_party_settings: {  }
   field_ucb_category_display:
     type: boolean_checkbox
-    weight: 101
+    weight: 2
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   name:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
@@ -37,18 +37,18 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 30
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
   simple_sitemap:
-    weight: 10
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 100
+    weight: 5
     region: content
     settings:
       display_label: true

--- a/config/install/core.entity_form_display.taxonomy_term.tags.default.yml
+++ b/config/install/core.entity_form_display.taxonomy_term.tags.default.yml
@@ -13,23 +13,23 @@ bundle: tags
 mode: default
 content:
   description:
-    type: text_textfield
-    weight: 0
+    type: text_textarea
+    weight: 1
     region: content
     settings:
-      size: 60
+      rows: 5
       placeholder: ''
     third_party_settings: {  }
   field_ucb_tag_display:
     type: boolean_checkbox
-    weight: 101
+    weight: 2
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   name:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
@@ -37,18 +37,18 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 30
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
   simple_sitemap:
-    weight: 10
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 100
+    weight: 5
     region: content
     settings:
       display_label: true

--- a/config/install/core.entity_form_display.taxonomy_term.tags.default.yml
+++ b/config/install/core.entity_form_display.taxonomy_term.tags.default.yml
@@ -1,0 +1,56 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.tags.field_ucb_tag_display
+    - taxonomy.vocabulary.tags
+  module:
+    - path
+    - text
+id: taxonomy_term.tags.default
+targetEntityType: taxonomy_term
+bundle: tags
+mode: default
+content:
+  description:
+    type: text_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_ucb_tag_display:
+    type: boolean_checkbox
+    weight: 101
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 100
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden: {  }

--- a/config/install/core.entity_view_display.taxonomy_term.category.default.yml
+++ b/config/install/core.entity_view_display.taxonomy_term.category.default.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.category.field_ucb_category_display
+    - taxonomy.vocabulary.category
+  module:
+    - text
+id: taxonomy_term.category.default
+targetEntityType: taxonomy_term
+bundle: category
+mode: default
+content:
+  description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_ucb_category_display:
+    type: boolean
+    label: hidden
+    settings:
+      format: true-false
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden: {  }

--- a/config/install/core.entity_view_display.taxonomy_term.tags.default.yml
+++ b/config/install/core.entity_view_display.taxonomy_term.tags.default.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.tags.field_ucb_tag_display
+    - taxonomy.vocabulary.tags
+  module:
+    - text
+id: taxonomy_term.tags.default
+targetEntityType: taxonomy_term
+bundle: tags
+mode: default
+content:
+  description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_ucb_tag_display:
+    type: boolean
+    label: above
+    settings:
+      format: true-false
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden: {  }

--- a/config/install/field.field.taxonomy_term.category.field_ucb_category_display.yml
+++ b/config/install/field.field.taxonomy_term.category.field_ucb_category_display.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_ucb_category_display
+    - taxonomy.vocabulary.category
+id: taxonomy_term.category.field_ucb_category_display
+field_name: field_ucb_category_display
+entity_type: taxonomy_term
+bundle: category
+label: 'Category Display'
+description: 'Choose whether a Category will display to the visitor. This is useful for using Category tags to group Articles, for example, ''Homepage Articles'', that don''t need to be displayed in the Category list at the bottom of articles.'
+required: true
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/install/field.field.taxonomy_term.category.field_ucb_category_display.yml
+++ b/config/install/field.field.taxonomy_term.category.field_ucb_category_display.yml
@@ -10,7 +10,7 @@ entity_type: taxonomy_term
 bundle: category
 label: 'Category Display'
 description: 'Choose whether a Category will display to the visitor. This is useful for using Category tags to group Articles, for example, ''Homepage Articles'', that don''t need to be displayed in the Category list at the bottom of articles.'
-required: true
+required: false
 translatable: false
 default_value:
   -

--- a/config/install/field.field.taxonomy_term.tags.field_ucb_tag_display.yml
+++ b/config/install/field.field.taxonomy_term.tags.field_ucb_tag_display.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_ucb_tag_display
+    - taxonomy.vocabulary.tags
+id: taxonomy_term.tags.field_ucb_tag_display
+field_name: field_ucb_tag_display
+entity_type: taxonomy_term
+bundle: tags
+label: 'Tag Display'
+description: 'Choose whether a Tag will display to a visitor. This is useful for using Tags to group Articles. For example, ''Homepage Articles'', that don''t need to be displayed in the Tag list at the bottom of articles'
+required: true
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/install/field.field.taxonomy_term.tags.field_ucb_tag_display.yml
+++ b/config/install/field.field.taxonomy_term.tags.field_ucb_tag_display.yml
@@ -10,7 +10,7 @@ entity_type: taxonomy_term
 bundle: tags
 label: 'Tag Display'
 description: 'Choose whether a Tag will display to a visitor. This is useful for using Tags to group Articles. For example, ''Homepage Articles'', that don''t need to be displayed in the Tag list at the bottom of articles'
-required: true
+required: false
 translatable: false
 default_value:
   -

--- a/config/install/field.storage.taxonomy_term.field_ucb_category_display.yml
+++ b/config/install/field.storage.taxonomy_term.field_ucb_category_display.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_ucb_category_display
+field_name: field_ucb_category_display
+entity_type: taxonomy_term
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.taxonomy_term.field_ucb_tag_display.yml
+++ b/config/install/field.storage.taxonomy_term.field_ucb_tag_display.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_ucb_tag_display
+field_name: field_ucb_tag_display
+entity_type: taxonomy_term
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
Hidden Terms: Category and Tag schemas receive form option to toggle display for admin-only taxonomies.

Resolves [#217 ](https://github.com/CuBoulder/tiamat-theme/issues/217)

Change Includes:
- `tiamat-theme` => `issue/217`
- `tiamat-custom-entities` => `issue/217`
