### PR TITLE
Newsletter Email View Modes

### DIFF
--- a/config/install/core.entity_form_display.paragraph.newsletter_section.default.yml
+++ b/config/install/core.entity_form_display.paragraph.newsletter_section.default.yml
@@ -17,7 +17,7 @@ mode: default
 content:
   field_newsletter_section_link:
     type: link_default
-    weight: 2
+    weight: 3
     region: content
     settings:
       placeholder_url: ''
@@ -25,7 +25,7 @@ content:
     third_party_settings: {  }
   field_newsletter_section_select:
     type: paragraphs
-    weight: 3
+    weight: 2
     region: content
     settings:
       title: Paragraph

--- a/config/install/core.entity_view_display.node.newsletter.email_html.yml
+++ b/config/install/core.entity_view_display.node.newsletter.email_html.yml
@@ -1,0 +1,140 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.email_html
+    - field.field.node.newsletter.field_newsletter_block_text_one
+    - field.field.node.newsletter.field_newsletter_block_text_two
+    - field.field.node.newsletter.field_newsletter_block_title_one
+    - field.field.node.newsletter.field_newsletter_block_title_two
+    - field.field.node.newsletter.field_newsletter_intro_body
+    - field.field.node.newsletter.field_newsletter_intro_image
+    - field.field.node.newsletter.field_newsletter_promo_image_one
+    - field.field.node.newsletter.field_newsletter_promo_image_two
+    - field.field.node.newsletter.field_newsletter_promo_link_one
+    - field.field.node.newsletter.field_newsletter_promo_link_two
+    - field.field.node.newsletter.field_newsletter_section_block
+    - field.field.node.newsletter.field_newsletter_type
+    - node.type.newsletter
+  module:
+    - entity_reference_revisions
+    - layout_builder
+    - link
+    - text
+    - user
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: node.newsletter.email_html
+targetEntityType: node
+bundle: newsletter
+mode: email_html
+content:
+  field_newsletter_block_text_one:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_newsletter_block_text_two:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 6
+    region: content
+  field_newsletter_block_title_one:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_newsletter_block_title_two:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  field_newsletter_intro_body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_newsletter_intro_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_newsletter_promo_image_one:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    weight: 8
+    region: content
+  field_newsletter_promo_image_two:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    weight: 9
+    region: content
+  field_newsletter_promo_link_one:
+    type: link
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 11
+    region: content
+  field_newsletter_promo_link_two:
+    type: link
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 10
+    region: content
+  field_newsletter_section_block:
+    type: entity_reference_revisions_entity_view
+    label: hidden
+    settings:
+      view_mode: email_html
+      link: ''
+    third_party_settings: {  }
+    weight: 7
+    region: content
+  field_newsletter_type:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 2
+    region: content
+hidden:
+  links: true

--- a/config/install/core.entity_view_display.paragraph.newsletter_section.email_html.yml
+++ b/config/install/core.entity_view_display.paragraph.newsletter_section.email_html.yml
@@ -1,0 +1,61 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.email_html
+    - field.field.paragraph.newsletter_section.field_newsletter_section_link
+    - field.field.paragraph.newsletter_section.field_newsletter_section_select
+    - field.field.paragraph.newsletter_section.field_newsletter_section_style
+    - field.field.paragraph.newsletter_section.field_newsletter_section_title
+    - paragraphs.paragraphs_type.newsletter_section
+  module:
+    - entity_reference_revisions
+    - layout_builder
+    - link
+    - options
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: paragraph.newsletter_section.email_html
+targetEntityType: paragraph
+bundle: newsletter_section
+mode: email_html
+content:
+  field_newsletter_section_link:
+    type: link
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_newsletter_section_select:
+    type: entity_reference_revisions_entity_view
+    label: hidden
+    settings:
+      view_mode: email_html
+      link: ''
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_newsletter_section_style:
+    type: list_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_newsletter_section_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+hidden: {  }

--- a/config/install/core.entity_view_display.paragraph.newsletter_section_article.email_html.yml
+++ b/config/install/core.entity_view_display.paragraph.newsletter_section_article.email_html.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.email_html
+    - field.field.paragraph.newsletter_section_article.field_newsletter_article_select
+    - paragraphs.paragraphs_type.newsletter_section_article
+  module:
+    - layout_builder
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: paragraph.newsletter_section_article.email_html
+targetEntityType: paragraph
+bundle: newsletter_section_article
+mode: email_html
+content:
+  field_newsletter_article_select:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden: {  }

--- a/config/install/core.entity_view_display.paragraph.newsletter_section_content.email_html.yml
+++ b/config/install/core.entity_view_display.paragraph.newsletter_section_content.email_html.yml
@@ -1,0 +1,55 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.email_html
+    - field.field.paragraph.newsletter_section_content.field_news_content_categories
+    - field.field.paragraph.newsletter_section_content.field_newsletter_content_image
+    - field.field.paragraph.newsletter_section_content.field_newsletter_content_text
+    - field.field.paragraph.newsletter_section_content.field_newsletter_content_title
+    - paragraphs.paragraphs_type.newsletter_section_content
+  module:
+    - layout_builder
+    - text
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: paragraph.newsletter_section_content.email_html
+targetEntityType: paragraph
+bundle: newsletter_section_content
+mode: email_html
+content:
+  field_news_content_categories:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_newsletter_content_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_newsletter_content_text:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_newsletter_content_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden: {  }

--- a/config/install/core.entity_view_mode.node.email_html.yml
+++ b/config/install/core.entity_view_mode.node.email_html.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.email_html
+label: 'Email HTML'
+targetEntityType: node
+cache: true

--- a/config/install/core.entity_view_mode.paragraph.email_html.yml
+++ b/config/install/core.entity_view_mode.paragraph.email_html.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.email_html
+label: 'Email HTML'
+targetEntityType: paragraph
+cache: true


### PR DESCRIPTION
Adds `Email HTML` View Modes for the Newsletter Node, allowing for dual render styles to satisfy Newsletter requirements
Partially resolves https://github.com/CuBoulder/tiamat-theme/issues/222

Includes:
`tiamat-theme` => issue/222
`tiamat-custom-entities` => issue/222