### PR TITLE
Changes "Order by" for Person List page

### DIFF
--- a/config/install/field.storage.node.field_ucb_people_order_by.yml
+++ b/config/install/field.storage.node.field_ucb_people_order_by.yml
@@ -15,7 +15,7 @@ settings:
       label: 'Last Name'
     -
       value: type
-      label: 'Has Job Type, Last Name'
+      label: 'Job Type, Last Name'
   allowed_values_function: ''
 module: options
 locked: false


### PR DESCRIPTION
The option "Has Job Type, Last Name" has become "Job Type, Last Name". Rather than simply checking for the existence of the _job type_, sorting is performed alphabetically by a person's first _job type_.

CuBoulder/tiamat-theme#280; Author @TeddyBearX 
Sister PR in: [tiamat-theme](https://github.com/CuBoulder/tiamat-theme/pull/287)