### PR TITLE
Adds pronouns field to the Person page

### DIFF
--- a/config/install/core.entity_form_display.node.ucb_person.default.yml
+++ b/config/install/core.entity_form_display.node.ucb_person.default.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.ucb_person.field_ucb_person_office_hours
     - field.field.node.ucb_person.field_ucb_person_phone
     - field.field.node.ucb_person.field_ucb_person_photo
+    - field.field.node.ucb_person.field_ucb_person_pronouns
     - field.field.node.ucb_person.field_ucb_person_title
     - node.type.ucb_person
   module:
@@ -49,6 +50,7 @@ third_party_settings:
         - title
         - field_ucb_person_first_name
         - field_ucb_person_last_name
+        - field_ucb_person_pronouns
         - field_ucb_person_job_type
         - field_ucb_person_title
         - field_ucb_person_department
@@ -103,7 +105,6 @@ third_party_settings:
         required_fields: false
     group_body:
       children:
-        - field_ucb_person_summary
         - body
       label: Body
       region: content
@@ -142,7 +143,7 @@ content:
     third_party_settings: {  }
   field_ucb_person_department:
     type: entity_reference_autocomplete
-    weight: 7
+    weight: 8
     region: content
     settings:
       match_operator: CONTAINS
@@ -198,7 +199,7 @@ content:
     third_party_settings: {  }
   field_ucb_person_job_type:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 6
     region: content
     settings:
       match_operator: CONTAINS
@@ -239,14 +240,22 @@ content:
     third_party_settings: {  }
   field_ucb_person_photo:
     type: media_library_widget
-    weight: 8
+    weight: 9
     region: content
     settings:
       media_types: {  }
     third_party_settings: {  }
+  field_ucb_person_pronouns:
+    type: string_textfield
+    weight: 5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_ucb_person_title:
     type: string_textfield
-    weight: 6
+    weight: 7
     region: content
     settings:
       size: 60

--- a/config/install/core.entity_view_display.node.ucb_person.default.yml
+++ b/config/install/core.entity_view_display.node.ucb_person.default.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.ucb_person.field_ucb_person_office_hours
     - field.field.node.ucb_person.field_ucb_person_phone
     - field.field.node.ucb_person.field_ucb_person_photo
+    - field.field.node.ucb_person.field_ucb_person_pronouns
     - field.field.node.ucb_person.field_ucb_person_title
     - node.type.ucb_person
   module:
@@ -140,6 +141,14 @@ content:
       link: false
     third_party_settings: {  }
     weight: 5
+    region: content
+  field_ucb_person_pronouns:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 17
     region: content
   field_ucb_person_title:
     type: string

--- a/config/install/core.entity_view_display.node.ucb_person.teaser.yml
+++ b/config/install/core.entity_view_display.node.ucb_person.teaser.yml
@@ -17,6 +17,7 @@ dependencies:
     - field.field.node.ucb_person.field_ucb_person_office_hours
     - field.field.node.ucb_person.field_ucb_person_phone
     - field.field.node.ucb_person.field_ucb_person_photo
+    - field.field.node.ucb_person.field_ucb_person_pronouns
     - field.field.node.ucb_person.field_ucb_person_title
     - node.type.ucb_person
   module:
@@ -54,4 +55,5 @@ hidden:
   field_ucb_person_office_hours: true
   field_ucb_person_phone: true
   field_ucb_person_photo: true
+  field_ucb_person_pronouns: true
   field_ucb_person_title: true

--- a/config/install/field.field.node.ucb_person.field_ucb_person_pronouns.yml
+++ b/config/install/field.field.node.ucb_person.field_ucb_person_pronouns.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_person_pronouns
+    - node.type.ucb_person
+id: node.ucb_person.field_ucb_person_pronouns
+field_name: field_ucb_person_pronouns
+entity_type: node
+bundle: ucb_person
+label: Pronouns
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/install/field.storage.node.field_ucb_person_pronouns.yml
+++ b/config/install/field.storage.node.field_ucb_person_pronouns.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_ucb_person_pronouns
+field_name: field_ucb_person_pronouns
+entity_type: node
+type: string
+settings:
+  max_length: 32
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
A pronouns text field has been added to the Person page, allowing a person's pronouns to be displayed below their name.

CuBoulder/tiamat-theme#315

Sister PR in: [tiamat-theme](https://github.com/CuBoulder/tiamat-theme/pull/327)