### PR TITLE
Change: Newsletter Taxonomy Enhancements and Newsletter URL Path

### DIFF
--- a/config/install/core.entity_form_display.node.newsletter.default.yml
+++ b/config/install/core.entity_form_display.node.newsletter.default.yml
@@ -209,14 +209,15 @@ content:
         duplicate: duplicate
     third_party_settings: {  }
   field_newsletter_type:
-    type: entity_reference_autocomplete
+    type: options_select
     weight: 19
     region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+    settings: {  }
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
     third_party_settings: {  }
   title:
     type: string_textfield

--- a/config/install/core.entity_form_display.taxonomy_term.newsletter.default.yml
+++ b/config/install/core.entity_form_display.taxonomy_term.newsletter.default.yml
@@ -1,0 +1,84 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.newsletter.field_newsletter_design
+    - field.field.taxonomy_term.newsletter.field_newsletter_footer
+    - field.field.taxonomy_term.newsletter.field_newsletter_name_image
+    - field.field.taxonomy_term.newsletter.field_newsletter_path
+    - image.style.thumbnail
+    - taxonomy.vocabulary.newsletter
+  module:
+    - image
+    - path
+    - text
+id: taxonomy_term.newsletter.default
+targetEntityType: taxonomy_term
+bundle: newsletter
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_newsletter_design:
+    type: options_select
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_newsletter_footer:
+    type: text_textarea
+    weight: 5
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_newsletter_name_image:
+    type: image_image
+    weight: 3
+    region: content
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  field_newsletter_path:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 7
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 8
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden: {  }

--- a/config/install/core.entity_view_display.taxonomy_term.newsletter.default.yml
+++ b/config/install/core.entity_view_display.taxonomy_term.newsletter.default.yml
@@ -1,0 +1,59 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.newsletter.field_newsletter_design
+    - field.field.taxonomy_term.newsletter.field_newsletter_footer
+    - field.field.taxonomy_term.newsletter.field_newsletter_name_image
+    - field.field.taxonomy_term.newsletter.field_newsletter_path
+    - taxonomy.vocabulary.newsletter
+  module:
+    - image
+    - options
+    - text
+id: taxonomy_term.newsletter.default
+targetEntityType: taxonomy_term
+bundle: newsletter
+mode: default
+content:
+  description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_newsletter_design:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_newsletter_footer:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_newsletter_name_image:
+    type: image
+    label: above
+    settings:
+      image_link: ''
+      image_style: ''
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_newsletter_path:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 4
+    region: content
+hidden: {  }

--- a/config/install/field.field.taxonomy_term.newsletter.field_newsletter_design.yml
+++ b/config/install/field.field.taxonomy_term.newsletter.field_newsletter_design.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_newsletter_design
+    - taxonomy.vocabulary.newsletter
+  module:
+    - options
+id: taxonomy_term.newsletter.field_newsletter_design
+field_name: field_newsletter_design
+entity_type: taxonomy_term
+bundle: newsletter
+label: Design
+description: "Choose a design for the email version of the newsletter. The web version will be displayed in the site's design.\r\n"
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.field.taxonomy_term.newsletter.field_newsletter_footer.yml
+++ b/config/install/field.field.taxonomy_term.newsletter.field_newsletter_footer.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_newsletter_footer
+    - taxonomy.vocabulary.newsletter
+  module:
+    - text
+id: taxonomy_term.newsletter.field_newsletter_footer
+field_name: field_newsletter_footer
+entity_type: taxonomy_term
+bundle: newsletter
+label: 'Email Footer'
+description: 'This text is displayed at the bottom of the email version of a newsletter.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/install/field.field.taxonomy_term.newsletter.field_newsletter_name_image.yml
+++ b/config/install/field.field.taxonomy_term.newsletter.field_newsletter_name_image.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_newsletter_name_image
+    - taxonomy.vocabulary.newsletter
+  module:
+    - image
+id: taxonomy_term.newsletter.field_newsletter_name_image
+field_name: field_newsletter_name_image
+entity_type: taxonomy_term
+bundle: newsletter
+label: Image
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+field_type: image

--- a/config/install/field.field.taxonomy_term.newsletter.field_newsletter_path.yml
+++ b/config/install/field.field.taxonomy_term.newsletter.field_newsletter_path.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_newsletter_path
+    - taxonomy.vocabulary.newsletter
+id: taxonomy_term.newsletter.field_newsletter_path
+field_name: field_newsletter_path
+entity_type: taxonomy_term
+bundle: newsletter
+label: 'Newsletter Path'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/install/field.storage.taxonomy_term.field_newsletter_design.yml
+++ b/config/install/field.storage.taxonomy_term.field_newsletter_design.yml
@@ -1,0 +1,35 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - taxonomy
+id: taxonomy_term.field_newsletter_design
+field_name: field_newsletter_design
+entity_type: taxonomy_term
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: classic
+      label: Classic
+    -
+      value: minimal
+      label: Minimal
+    -
+      value: lightbox
+      label: 'Light Boxed'
+    -
+      value: darkbox
+      label: 'Dark Boxed'
+    -
+      value: simple
+      label: Simple
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.taxonomy_term.field_newsletter_footer.yml
+++ b/config/install/field.storage.taxonomy_term.field_newsletter_footer.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+    - text
+id: taxonomy_term.field_newsletter_footer
+field_name: field_newsletter_footer
+entity_type: taxonomy_term
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.taxonomy_term.field_newsletter_name_image.yml
+++ b/config/install/field.storage.taxonomy_term.field_newsletter_name_image.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - taxonomy
+id: taxonomy_term.field_newsletter_name_image
+field_name: field_newsletter_name_image
+entity_type: taxonomy_term
+type: image
+settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.taxonomy_term.field_newsletter_path.yml
+++ b/config/install/field.storage.taxonomy_term.field_newsletter_path.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_newsletter_path
+field_name: field_newsletter_path
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/pathauto.pattern.ucb_newsletter.yml
+++ b/config/install/pathauto.pattern.ucb_newsletter.yml
@@ -6,12 +6,12 @@ dependencies:
 id: ucb_newsletter
 label: 'UCB Newsletter'
 type: 'canonical_entities:node'
-pattern: 'newsletter/[node:created:custom:Y]/[node:created:custom:m]/[node:created:custom:d]/[node:title]'
+pattern: 'newsletter/[node:field_newsletter_type:entity:field_newsletter_path]/[node:title]'
 selection_criteria:
-  2ef6aeca-7062-454c-b9a0-68187ec5fc30:
+  a44aff48-b6df-4198-8767-027c4caa0d78:
     id: 'entity_bundle:node'
     negate: false
-    uuid: 2ef6aeca-7062-454c-b9a0-68187ec5fc30
+    uuid: a44aff48-b6df-4198-8767-027c4caa0d78
     context_mapping:
       node: node
     bundles:


### PR DESCRIPTION
Resolves https://github.com/CuBoulder/tiamat-theme/issues/306

Adds the following fields to the Newsletter Taxonomy type to eventually be used in styling the Newsletter email render:
- Design
- Email Footer
- Image
- Newsletter Path*

Also changes pathauto for Newsletters to follow this pattern:
_/newsletter/newsletter-path*/title_