### PR TITLE
New Block Type: Article Feature

### DIFF
--- a/config/install/block_content.type.ucb_article_feature.yml
+++ b/config/install/block_content.type.ucb_article_feature.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: ucb_article_feature
+label: 'Article Feature'
+revision: 0
+description: 'The Article Feature block displays the latest articles with the first article displaying a large image and summary and the remaining articles displaying titles and thumbnails. Articles must have a thumbnail set to display here.'

--- a/config/install/core.entity_form_display.block_content.ucb_article_feature.default.yml
+++ b/config/install/core.entity_form_display.block_content.ucb_article_feature.default.yml
@@ -1,0 +1,134 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_article_feature
+    - field.field.block_content.ucb_article_feature.body
+    - field.field.block_content.ucb_article_feature.field_article_feature_cat_excl
+    - field.field.block_content.ucb_article_feature.field_article_feature_cat_inc
+    - field.field.block_content.ucb_article_feature.field_article_feature_display
+    - field.field.block_content.ucb_article_feature.field_article_feature_image_size
+    - field.field.block_content.ucb_article_feature.field_article_feature_more_link
+    - field.field.block_content.ucb_article_feature.field_article_feature_tag_excl
+    - field.field.block_content.ucb_article_feature.field_article_feature_tag_inc
+  module:
+    - field_group
+    - link
+    - text
+third_party_settings:
+  field_group:
+    group_article_feature_filters:
+      children:
+        - group_article_feature_inc_filter
+        - group_article_feature_exc_filter
+      label: Filters
+      region: content
+      parent_name: ''
+      weight: 4
+      format_type: tabs
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        direction: horizontal
+        width_breakpoint: 640
+    group_article_feature_inc_filter:
+      children:
+        - field_article_feature_cat_inc
+        - field_article_feature_tag_inc
+      label: 'Include Filters'
+      region: content
+      parent_name: group_article_feature_filters
+      weight: 20
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: open
+        description: ''
+        required_fields: true
+    group_article_feature_exc_filter:
+      children:
+        - field_article_feature_cat_excl
+        - field_article_feature_tag_excl
+      label: 'Exclude Filters'
+      region: content
+      parent_name: group_article_feature_filters
+      weight: 21
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+id: block_content.ucb_article_feature.default
+targetEntityType: block_content
+bundle: ucb_article_feature
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 1
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+  field_article_feature_cat_excl:
+    type: options_buttons
+    weight: 7
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_article_feature_cat_inc:
+    type: options_buttons
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_article_feature_display:
+    type: options_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_article_feature_image_size:
+    type: options_select
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_article_feature_more_link:
+    type: link_default
+    weight: 9
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  field_article_feature_tag_excl:
+    type: options_buttons
+    weight: 8
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_article_feature_tag_inc:
+    type: options_buttons
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  info:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/config/install/core.entity_view_display.block_content.ucb_article_feature.default.yml
+++ b/config/install/core.entity_view_display.block_content.ucb_article_feature.default.yml
@@ -1,0 +1,84 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_article_feature
+    - field.field.block_content.ucb_article_feature.body
+    - field.field.block_content.ucb_article_feature.field_article_feature_cat_excl
+    - field.field.block_content.ucb_article_feature.field_article_feature_cat_inc
+    - field.field.block_content.ucb_article_feature.field_article_feature_display
+    - field.field.block_content.ucb_article_feature.field_article_feature_image_size
+    - field.field.block_content.ucb_article_feature.field_article_feature_more_link
+    - field.field.block_content.ucb_article_feature.field_article_feature_tag_excl
+    - field.field.block_content.ucb_article_feature.field_article_feature_tag_inc
+  module:
+    - link
+    - options
+    - text
+id: block_content.ucb_article_feature.default
+targetEntityType: block_content
+bundle: ucb_article_feature
+mode: default
+content:
+  body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_article_feature_cat_excl:
+    type: entity_reference_entity_id
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 7
+    region: content
+  field_article_feature_cat_inc:
+    type: entity_reference_entity_id
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  field_article_feature_display:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_article_feature_image_size:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_article_feature_more_link:
+    type: link_separate
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_article_feature_tag_excl:
+    type: entity_reference_entity_id
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 8
+    region: content
+  field_article_feature_tag_inc:
+    type: entity_reference_entity_id
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 6
+    region: content
+hidden: {  }

--- a/config/install/field.field.block_content.ucb_article_feature.body.yml
+++ b/config/install/field.field.block_content.ucb_article_feature.body.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_article_feature
+    - field.storage.block_content.body
+  module:
+    - text
+id: block_content.ucb_article_feature.body
+field_name: body
+entity_type: block_content
+bundle: ucb_article_feature
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+  required_summary: false
+field_type: text_with_summary

--- a/config/install/field.field.block_content.ucb_article_feature.field_article_feature_cat_excl.yml
+++ b/config/install/field.field.block_content.ucb_article_feature.field_article_feature_cat_excl.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_article_feature
+    - field.storage.block_content.field_article_feature_cat_excl
+    - taxonomy.vocabulary.category
+id: block_content.ucb_article_feature.field_article_feature_cat_excl
+field_name: field_article_feature_cat_excl
+entity_type: block_content
+bundle: ucb_article_feature
+label: 'Category Exclude'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      category: category
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.block_content.ucb_article_feature.field_article_feature_cat_inc.yml
+++ b/config/install/field.field.block_content.ucb_article_feature.field_article_feature_cat_inc.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_article_feature
+    - field.storage.block_content.field_article_feature_cat_inc
+    - taxonomy.vocabulary.category
+id: block_content.ucb_article_feature.field_article_feature_cat_inc
+field_name: field_article_feature_cat_inc
+entity_type: block_content
+bundle: ucb_article_feature
+label: 'Category Include'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      category: category
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.block_content.ucb_article_feature.field_article_feature_display.yml
+++ b/config/install/field.field.block_content.ucb_article_feature.field_article_feature_display.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_article_feature
+    - field.storage.block_content.field_article_feature_display
+  module:
+    - options
+id: block_content.ucb_article_feature.field_article_feature_display
+field_name: field_article_feature_display
+entity_type: block_content
+bundle: ucb_article_feature
+label: Display
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: inline-half
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.field.block_content.ucb_article_feature.field_article_feature_image_size.yml
+++ b/config/install/field.field.block_content.ucb_article_feature.field_article_feature_image_size.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_article_feature
+    - field.storage.block_content.field_article_feature_image_size
+  module:
+    - options
+id: block_content.ucb_article_feature.field_article_feature_image_size
+field_name: field_article_feature_image_size
+entity_type: block_content
+bundle: ucb_article_feature
+label: 'Image Size'
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: regular
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.field.block_content.ucb_article_feature.field_article_feature_more_link.yml
+++ b/config/install/field.field.block_content.ucb_article_feature.field_article_feature_more_link.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_article_feature
+    - field.storage.block_content.field_article_feature_more_link
+  module:
+    - link
+id: block_content.ucb_article_feature.field_article_feature_more_link
+field_name: field_article_feature_more_link
+entity_type: block_content
+bundle: ucb_article_feature
+label: 'More Link'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 1
+  link_type: 17
+field_type: link

--- a/config/install/field.field.block_content.ucb_article_feature.field_article_feature_tag_excl.yml
+++ b/config/install/field.field.block_content.ucb_article_feature.field_article_feature_tag_excl.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_article_feature
+    - field.storage.block_content.field_article_feature_tag_excl
+    - taxonomy.vocabulary.tags
+id: block_content.ucb_article_feature.field_article_feature_tag_excl
+field_name: field_article_feature_tag_excl
+entity_type: block_content
+bundle: ucb_article_feature
+label: 'Tag Exclude'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      tags: tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.block_content.ucb_article_feature.field_article_feature_tag_inc.yml
+++ b/config/install/field.field.block_content.ucb_article_feature.field_article_feature_tag_inc.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_article_feature
+    - field.storage.block_content.field_article_feature_tag_inc
+    - taxonomy.vocabulary.tags
+id: block_content.ucb_article_feature.field_article_feature_tag_inc
+field_name: field_article_feature_tag_inc
+entity_type: block_content
+bundle: ucb_article_feature
+label: 'Tag Include'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      tags: tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.storage.block_content.field_article_feature_cat_excl.yml
+++ b/config/install/field.storage.block_content.field_article_feature_cat_excl.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - taxonomy
+id: block_content.field_article_feature_cat_excl
+field_name: field_article_feature_cat_excl
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_article_feature_cat_inc.yml
+++ b/config/install/field.storage.block_content.field_article_feature_cat_inc.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - taxonomy
+id: block_content.field_article_feature_cat_inc
+field_name: field_article_feature_cat_inc
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_article_feature_display.yml
+++ b/config/install/field.storage.block_content.field_article_feature_display.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - options
+id: block_content.field_article_feature_display
+field_name: field_article_feature_display
+entity_type: block_content
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: inline-half
+      label: 'Inline 50/50'
+    -
+      value: inline-large
+      label: 'Inline 66/33'
+    -
+      value: stacked
+      label: Stacked
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_article_feature_image_size.yml
+++ b/config/install/field.storage.block_content.field_article_feature_image_size.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - options
+id: block_content.field_article_feature_image_size
+field_name: field_article_feature_image_size
+entity_type: block_content
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: regular
+      label: 'Regular (3:2 aspect ratio)'
+    -
+      value: wide
+      label: 'Wide (slider image style)'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_article_feature_more_link.yml
+++ b/config/install/field.storage.block_content.field_article_feature_more_link.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - link
+id: block_content.field_article_feature_more_link
+field_name: field_article_feature_more_link
+entity_type: block_content
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_article_feature_tag_excl.yml
+++ b/config/install/field.storage.block_content.field_article_feature_tag_excl.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - taxonomy
+id: block_content.field_article_feature_tag_excl
+field_name: field_article_feature_tag_excl
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_article_feature_tag_inc.yml
+++ b/config/install/field.storage.block_content.field_article_feature_tag_inc.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - taxonomy
+id: block_content.field_article_feature_tag_inc
+field_name: field_article_feature_tag_inc
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
Adds a new block type: Article Feature. The Article Feature block displays the latest Articles, with Category & Tag filters set by the user much like the Article List page. The first Article displays a large image and summary and the remaining articles displays titles and thumbnails. 

Resolves [#318 ](https://github.com/CuBoulder/tiamat-theme/issues/318)

Includes:

- `tiamat-theme` => `issue/tiamat-theme/318`
- `tiamat-custom-entities` => `issue/tiamat-theme/318`