### PR TITLE
New Block Type: Article Slider

### DIFF
--- a/config/install/block_content.type.ucb_article_slider.yml
+++ b/config/install/block_content.type.ucb_article_slider.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: ucb_article_slider
+label: 'Article Slider'
+revision: 0
+description: 'Displays a maximum of 6 Articles in an interactive slider. Articles must have a thumbnail to appear here'

--- a/config/install/core.entity_form_display.block_content.ucb_article_slider.default.yml
+++ b/config/install/core.entity_form_display.block_content.ucb_article_slider.default.yml
@@ -1,0 +1,110 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_article_slider
+    - field.field.block_content.ucb_article_slider.body
+    - field.field.block_content.ucb_article_slider.field_article_slider_cat_exclude
+    - field.field.block_content.ucb_article_slider.field_article_slider_cat_include
+    - field.field.block_content.ucb_article_slider.field_article_slider_tag_exclude
+    - field.field.block_content.ucb_article_slider.field_article_slider_tag_include
+  module:
+    - field_group
+    - text
+third_party_settings:
+  field_group:
+    group_article_slider_filters:
+      children:
+        - group_article_slider_inc_filters
+        - group_article_slider_exc_filters
+      label: Filters
+      region: content
+      parent_name: ''
+      weight: 2
+      format_type: tabs
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        direction: horizontal
+        width_breakpoint: 640
+    group_article_slider_inc_filters:
+      children:
+        - field_article_slider_cat_include
+        - field_article_slider_tag_include
+      label: 'Include Filters'
+      region: content
+      parent_name: group_article_slider_filters
+      weight: 7
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: open
+        description: ''
+        required_fields: true
+    group_article_slider_exc_filters:
+      children:
+        - field_article_slider_cat_exclude
+        - field_article_slider_tag_exclude
+      label: 'Exclude FIlters'
+      region: content
+      parent_name: group_article_slider_filters
+      weight: 8
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+id: block_content.ucb_article_slider.default
+targetEntityType: block_content
+bundle: ucb_article_slider
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 1
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+  field_article_slider_cat_exclude:
+    type: options_buttons
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_article_slider_cat_include:
+    type: options_buttons
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_article_slider_tag_exclude:
+    type: options_buttons
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_article_slider_tag_include:
+    type: options_buttons
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  info:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/config/install/core.entity_view_display.block_content.ucb_article_slider.default.yml
+++ b/config/install/core.entity_view_display.block_content.ucb_article_slider.default.yml
@@ -1,0 +1,53 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_article_slider
+    - field.field.block_content.ucb_article_slider.body
+    - field.field.block_content.ucb_article_slider.field_article_slider_cat_exclude
+    - field.field.block_content.ucb_article_slider.field_article_slider_cat_include
+    - field.field.block_content.ucb_article_slider.field_article_slider_tag_exclude
+    - field.field.block_content.ucb_article_slider.field_article_slider_tag_include
+  module:
+    - text
+id: block_content.ucb_article_slider.default
+targetEntityType: block_content
+bundle: ucb_article_slider
+mode: default
+content:
+  body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_article_slider_cat_exclude:
+    type: entity_reference_entity_id
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_article_slider_cat_include:
+    type: entity_reference_entity_id
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_article_slider_tag_exclude:
+    type: entity_reference_entity_id
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_article_slider_tag_include:
+    type: entity_reference_entity_id
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
+    region: content
+hidden: {  }

--- a/config/install/field.field.block_content.ucb_article_slider.body.yml
+++ b/config/install/field.field.block_content.ucb_article_slider.body.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_article_slider
+    - field.storage.block_content.body
+  module:
+    - text
+id: block_content.ucb_article_slider.body
+field_name: body
+entity_type: block_content
+bundle: ucb_article_slider
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+  required_summary: false
+field_type: text_with_summary

--- a/config/install/field.field.block_content.ucb_article_slider.field_article_slider_cat_exclude.yml
+++ b/config/install/field.field.block_content.ucb_article_slider.field_article_slider_cat_exclude.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_article_slider
+    - field.storage.block_content.field_article_slider_cat_exclude
+    - taxonomy.vocabulary.category
+id: block_content.ucb_article_slider.field_article_slider_cat_exclude
+field_name: field_article_slider_cat_exclude
+entity_type: block_content
+bundle: ucb_article_slider
+label: 'Category Exclude'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      category: category
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.block_content.ucb_article_slider.field_article_slider_cat_include.yml
+++ b/config/install/field.field.block_content.ucb_article_slider.field_article_slider_cat_include.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_article_slider
+    - field.storage.block_content.field_article_slider_cat_include
+    - taxonomy.vocabulary.category
+id: block_content.ucb_article_slider.field_article_slider_cat_include
+field_name: field_article_slider_cat_include
+entity_type: block_content
+bundle: ucb_article_slider
+label: 'Category Include'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      category: category
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.block_content.ucb_article_slider.field_article_slider_tag_exclude.yml
+++ b/config/install/field.field.block_content.ucb_article_slider.field_article_slider_tag_exclude.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_article_slider
+    - field.storage.block_content.field_article_slider_tag_exclude
+    - taxonomy.vocabulary.tags
+id: block_content.ucb_article_slider.field_article_slider_tag_exclude
+field_name: field_article_slider_tag_exclude
+entity_type: block_content
+bundle: ucb_article_slider
+label: 'Tag Exclude'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      tags: tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.block_content.ucb_article_slider.field_article_slider_tag_include.yml
+++ b/config/install/field.field.block_content.ucb_article_slider.field_article_slider_tag_include.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_article_slider
+    - field.storage.block_content.field_article_slider_tag_include
+    - taxonomy.vocabulary.tags
+id: block_content.ucb_article_slider.field_article_slider_tag_include
+field_name: field_article_slider_tag_include
+entity_type: block_content
+bundle: ucb_article_slider
+label: 'Tag Include'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      tags: tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.storage.block_content.field_article_slider_cat_exclude.yml
+++ b/config/install/field.storage.block_content.field_article_slider_cat_exclude.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - taxonomy
+id: block_content.field_article_slider_cat_exclude
+field_name: field_article_slider_cat_exclude
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_article_slider_cat_include.yml
+++ b/config/install/field.storage.block_content.field_article_slider_cat_include.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - taxonomy
+id: block_content.field_article_slider_cat_include
+field_name: field_article_slider_cat_include
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_article_slider_tag_exclude.yml
+++ b/config/install/field.storage.block_content.field_article_slider_tag_exclude.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - taxonomy
+id: block_content.field_article_slider_tag_exclude
+field_name: field_article_slider_tag_exclude
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_article_slider_tag_include.yml
+++ b/config/install/field.storage.block_content.field_article_slider_tag_include.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - taxonomy
+id: block_content.field_article_slider_tag_include
+field_name: field_article_slider_tag_include
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
Adds the Article Slider block. Much like the Article List page and other Article blocks, this will display a maximum of 6 articles in an interactive slider using user-provided inclusion and exclusion filters.

Resolves [#319 ](https://github.com/CuBoulder/tiamat-theme/issues/319)

Includes:
`tiamat-theme` => `issue/tiamat-theme/319`
`tiamat-custom-entities` => `issue/tiamat-theme/319`