### PR TITLE
Adds Additional Events link to Event Calendar block

### DIFF
--- a/config/install/core.entity_form_display.block_content.events_calendar.default.yml
+++ b/config/install/core.entity_form_display.block_content.events_calendar.default.yml
@@ -3,12 +3,23 @@ status: true
 dependencies:
   config:
     - block_content.type.events_calendar
+    - field.field.block_content.events_calendar.field_additional_events_link
     - field.field.block_content.events_calendar.field_calendar_code
+  module:
+    - link
 id: block_content.events_calendar.default
 targetEntityType: block_content
 bundle: events_calendar
 mode: default
 content:
+  field_additional_events_link:
+    type: link_default
+    weight: 27
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
   field_calendar_code:
     type: string_textarea
     weight: 26

--- a/config/install/core.entity_view_display.block_content.events_calendar.default.yml
+++ b/config/install/core.entity_view_display.block_content.events_calendar.default.yml
@@ -3,12 +3,27 @@ status: true
 dependencies:
   config:
     - block_content.type.events_calendar
+    - field.field.block_content.events_calendar.field_additional_events_link
     - field.field.block_content.events_calendar.field_calendar_code
+  module:
+    - link
 id: block_content.events_calendar.default
 targetEntityType: block_content
 bundle: events_calendar
 mode: default
 content:
+  field_additional_events_link:
+    type: link
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_calendar_code:
     type: basic_string
     label: hidden

--- a/config/install/field.field.block_content.events_calendar.field_additional_events_link.yml
+++ b/config/install/field.field.block_content.events_calendar.field_additional_events_link.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.events_calendar
+    - field.storage.block_content.field_additional_events_link
+  module:
+    - link
+id: block_content.events_calendar.field_additional_events_link
+field_name: field_additional_events_link
+entity_type: block_content
+bundle: events_calendar
+label: 'Additional Events Link'
+description: 'Provide a link for additional events to display beneath the Calendar Block'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 1
+  link_type: 17
+field_type: link

--- a/config/install/field.storage.block_content.field_additional_events_link.yml
+++ b/config/install/field.storage.block_content.field_additional_events_link.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - link
+id: block_content.field_additional_events_link
+field_name: field_additional_events_link
+entity_type: block_content
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
Resolves https://github.com/CuBoulder/tiamat-theme/issues/381 - Adds a Link field to the Events Calendar Block to allow for links to additional events.

Includes:
[tiamat-theme](https://github.com/CuBoulder/tiamat-theme) => [issue/tiamat-theme/381 ](https://github.com/CuBoulder/tiamat-theme/pull/411)
[tiamat-custom-entities](https://github.com/CuBoulder/tiamat-custom-entities) => [issue/tiamat-theme/381](https://github.com/CuBoulder/tiamat-custom-entities/pull/65)
