### PR TITLE
Change: Adds 'White' background to card-styled Text Block

### DIFF
--- a/config/install/field.storage.block_content.field_text_block_background.yml
+++ b/config/install/field.storage.block_content.field_text_block_background.yml
@@ -25,6 +25,9 @@ settings:
     -
       value: '4'
       label: Gold
+    - 
+      value: '5'
+      label: White
   allowed_values_function: ''
 module: options
 locked: false


### PR DESCRIPTION
Adds a White background option to card-style Text Block for the case where sections have a different colored background

Includes:

- `tiamat-theme` => `issue/tiamat-theme/413`
- `tiamat-custom-entities` => `issue/tiamat-theme/413`

Resolves https://github.com/CuBoulder/tiamat-theme/issues/413