### PR TITLE
Removes "D9" from theme name and the theme, custom entities Composer package names

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "cu-boulder/ucb_d9_custom_entities",
-    "description": "Custom D9 content schemas for CU Boulder Web Express",
+    "name": "cu-boulder/ucb_custom_entities",
+    "description": "University of Colorado Boulder custom entities",
     "license": "MIT",
     "type": "drupal-custom-module"
 }

--- a/cu_boulder_content_types.info.yml
+++ b/cu_boulder_content_types.info.yml
@@ -1,9 +1,8 @@
-name: 'CU Boulder Content Types'
-description: 'Entity content schemas for the content types used by CU Boulder D9 websites.  '
+name: 'University of Colorado Boulder custom entities'
+description: 'Entity content schemas for the content types used by CU Boulder websites.'
 type: module
 core_version_requirement: '^9 || ^10'
 dependencies:
-  - cu_boulder_content_types
   - field
   - field_group
   - layout_builder
@@ -18,4 +17,4 @@ dependencies:
   - text
   - user
 version: '0.8'
-package: 'CU Boulder Content Types'
+package: 'CU Boulder'


### PR DESCRIPTION
CuBoulder/tiamat-theme#435

Sister PR in: [tiamat-theme](https://github.com/CuBoulder/tiamat-theme/pull/452), [tiamat-profile](https://github.com/CuBoulder/tiamat-profile/pull/52), [tiamat10-profile](https://github.com/CuBoulder/tiamat10-profile/pull/13), [tiamat-project-template](https://github.com/CuBoulder/tiamat-project-template/pull/28), [tiamat10-project-template](https://github.com/CuBoulder/tiamat10-project-template/pull/8), [ucb_site_configuration](https://github.com/CuBoulder/ucb_site_configuration/pull/26)