### PR TITLE
Removes image requirement from Content Row "Teaser" layouts

### DIFF
--- a/config/install/field.field.paragraph.row_layout_content.field_row_layout_content_image.yml
+++ b/config/install/field.field.paragraph.row_layout_content.field_row_layout_content_image.yml
@@ -10,8 +10,8 @@ field_name: field_row_layout_content_image
 entity_type: paragraph
 bundle: row_layout_content
 label: Image
-description: ''
-required: true
+description: 'Adding an image is recommended for the Tiles and Features layouts.'
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
This update enables the creation of Content Row blocks with image-less content and displays it correctly in the "Teasers" and "Teasers Alternate" layouts.

CuBoulder/tiamat-theme#453

Sister PR in: [tiamat-theme](https://github.com/CuBoulder/tiamat-theme/pull/457)