### PR TITLE
New: Adds 'People List Block'

### DIFF
--- a/config/install/block_content.type.ucb_people_list_block.yml
+++ b/config/install/block_content.type.ucb_people_list_block.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: ucb_people_list_block
+label: 'People List Block'
+revision: 0
+description: 'A configurable block that displays a list of People, similar to the Person List Page with simpler options. Block contains options for how your block will display to users (Teaser, Grid, Name & Thumbnail, Name Only) and selectable filters by taxonomies on a Person (Department, Job Type, Filter 1, 2, 3) to curate a specific list of People'

--- a/config/install/core.entity_form_display.block_content.ucb_people_list_block.default.yml
+++ b/config/install/core.entity_form_display.block_content.ucb_people_list_block.default.yml
@@ -1,0 +1,95 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_people_list_block
+    - field.field.block_content.ucb_people_list_block.body
+    - field.field.block_content.ucb_people_list_block.field_people_block_department
+    - field.field.block_content.ucb_people_list_block.field_people_block_display
+    - field.field.block_content.ucb_people_list_block.field_people_block_filter_1
+    - field.field.block_content.ucb_people_list_block.field_people_block_filter_2
+    - field.field.block_content.ucb_people_list_block.field_people_block_filter_3
+    - field.field.block_content.ucb_people_list_block.field_people_block_job_type
+  module:
+    - field_group
+    - text
+third_party_settings:
+  field_group:
+    group_people_block_filters:
+      children:
+        - field_people_block_department
+        - field_people_block_job_type
+        - field_people_block_filter_1
+        - field_people_block_filter_2
+        - field_people_block_filter_3
+      label: Filters
+      region: content
+      parent_name: ''
+      weight: 2
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: ''
+        required_fields: true
+id: block_content.ucb_people_list_block.default
+targetEntityType: block_content
+bundle: ucb_people_list_block
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 1
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+  field_people_block_department:
+    type: options_buttons
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_people_block_display:
+    type: options_select
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_people_block_filter_1:
+    type: options_buttons
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_people_block_filter_2:
+    type: options_buttons
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_people_block_filter_3:
+    type: options_buttons
+    weight: 7
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_people_block_job_type:
+    type: options_buttons
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  info:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/config/install/core.entity_view_display.block_content.ucb_people_list_block.default.yml
+++ b/config/install/core.entity_view_display.block_content.ucb_people_list_block.default.yml
@@ -1,0 +1,70 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_people_list_block
+    - field.field.block_content.ucb_people_list_block.body
+    - field.field.block_content.ucb_people_list_block.field_people_block_department
+    - field.field.block_content.ucb_people_list_block.field_people_block_display
+    - field.field.block_content.ucb_people_list_block.field_people_block_filter_1
+    - field.field.block_content.ucb_people_list_block.field_people_block_filter_2
+    - field.field.block_content.ucb_people_list_block.field_people_block_filter_3
+    - field.field.block_content.ucb_people_list_block.field_people_block_job_type
+  module:
+    - options
+    - text
+id: block_content.ucb_people_list_block.default
+targetEntityType: block_content
+bundle: ucb_people_list_block
+mode: default
+content:
+  body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_people_block_department:
+    type: entity_reference_entity_id
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_people_block_display:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 6
+    region: content
+  field_people_block_filter_1:
+    type: entity_reference_entity_id
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_people_block_filter_2:
+    type: entity_reference_entity_id
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_people_block_filter_3:
+    type: entity_reference_entity_id
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  field_people_block_job_type:
+    type: entity_reference_entity_id
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+hidden: {  }

--- a/config/install/field.field.block_content.ucb_people_list_block.body.yml
+++ b/config/install/field.field.block_content.ucb_people_list_block.body.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_people_list_block
+    - field.storage.block_content.body
+  module:
+    - text
+id: block_content.ucb_people_list_block.body
+field_name: body
+entity_type: block_content
+bundle: ucb_people_list_block
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+  required_summary: false
+  allowed_formats: {  }
+field_type: text_with_summary

--- a/config/install/field.field.block_content.ucb_people_list_block.field_people_block_department.yml
+++ b/config/install/field.field.block_content.ucb_people_list_block.field_people_block_department.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_people_list_block
+    - field.storage.block_content.field_people_block_department
+    - taxonomy.vocabulary.department
+id: block_content.ucb_people_list_block.field_people_block_department
+field_name: field_people_block_department
+entity_type: block_content
+bundle: ucb_people_list_block
+label: Department
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      department: department
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.block_content.ucb_people_list_block.field_people_block_display.yml
+++ b/config/install/field.field.block_content.ucb_people_list_block.field_people_block_display.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_people_list_block
+    - field.storage.block_content.field_people_block_display
+  module:
+    - options
+id: block_content.ucb_people_list_block.field_people_block_display
+field_name: field_people_block_display
+entity_type: block_content
+bundle: ucb_people_list_block
+label: Display
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: teaser
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.field.block_content.ucb_people_list_block.field_people_block_filter_1.yml
+++ b/config/install/field.field.block_content.ucb_people_list_block.field_people_block_filter_1.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_people_list_block
+    - field.storage.block_content.field_people_block_filter_1
+    - taxonomy.vocabulary.filter_1
+id: block_content.ucb_people_list_block.field_people_block_filter_1
+field_name: field_people_block_filter_1
+entity_type: block_content
+bundle: ucb_people_list_block
+label: 'Filter 1'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      filter_1: filter_1
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.block_content.ucb_people_list_block.field_people_block_filter_2.yml
+++ b/config/install/field.field.block_content.ucb_people_list_block.field_people_block_filter_2.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_people_list_block
+    - field.storage.block_content.field_people_block_filter_2
+    - taxonomy.vocabulary.filter_2
+id: block_content.ucb_people_list_block.field_people_block_filter_2
+field_name: field_people_block_filter_2
+entity_type: block_content
+bundle: ucb_people_list_block
+label: 'Filter 2'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      filter_2: filter_2
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.block_content.ucb_people_list_block.field_people_block_filter_3.yml
+++ b/config/install/field.field.block_content.ucb_people_list_block.field_people_block_filter_3.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_people_list_block
+    - field.storage.block_content.field_people_block_filter_3
+    - taxonomy.vocabulary.filter_3
+id: block_content.ucb_people_list_block.field_people_block_filter_3
+field_name: field_people_block_filter_3
+entity_type: block_content
+bundle: ucb_people_list_block
+label: 'Filter 3'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      filter_3: filter_3
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.block_content.ucb_people_list_block.field_people_block_job_type.yml
+++ b/config/install/field.field.block_content.ucb_people_list_block.field_people_block_job_type.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_people_list_block
+    - field.storage.block_content.field_people_block_job_type
+    - taxonomy.vocabulary.ucb_person_job_type
+id: block_content.ucb_people_list_block.field_people_block_job_type
+field_name: field_people_block_job_type
+entity_type: block_content
+bundle: ucb_people_list_block
+label: 'Job Type'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      ucb_person_job_type: ucb_person_job_type
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.storage.block_content.field_people_block_department.yml
+++ b/config/install/field.storage.block_content.field_people_block_department.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - taxonomy
+id: block_content.field_people_block_department
+field_name: field_people_block_department
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_people_block_display.yml
+++ b/config/install/field.storage.block_content.field_people_block_display.yml
@@ -14,7 +14,7 @@ settings:
       value: teaser
       label: Teaser
     -
-      value: gird
+      value: grid
       label: Grid
     -
       value: name-thumbnail

--- a/config/install/field.storage.block_content.field_people_block_display.yml
+++ b/config/install/field.storage.block_content.field_people_block_display.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - options
+id: block_content.field_people_block_display
+field_name: field_people_block_display
+entity_type: block_content
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: teaser
+      label: Teaser
+    -
+      value: gird
+      label: Grid
+    -
+      value: name-thumbnail
+      label: 'Name & Thumbnail'
+    -
+      value: name-only
+      label: Name
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_people_block_filter_1.yml
+++ b/config/install/field.storage.block_content.field_people_block_filter_1.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - taxonomy
+id: block_content.field_people_block_filter_1
+field_name: field_people_block_filter_1
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_people_block_filter_2.yml
+++ b/config/install/field.storage.block_content.field_people_block_filter_2.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - taxonomy
+id: block_content.field_people_block_filter_2
+field_name: field_people_block_filter_2
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_people_block_filter_3.yml
+++ b/config/install/field.storage.block_content.field_people_block_filter_3.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - taxonomy
+id: block_content.field_people_block_filter_3
+field_name: field_people_block_filter_3
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_people_block_job_type.yml
+++ b/config/install/field.storage.block_content.field_people_block_job_type.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - taxonomy
+id: block_content.field_people_block_job_type
+field_name: field_people_block_job_type
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
### People List Block
A configurable and placeable block that displays a list of People, similar to the Person List Page with simpler options. Block contains options for how your block will display to users (Teaser, Grid, Name & Thumbnail, Name Only) and selectable filters by taxonomies on a Person (Department, Job Type, Filter 1, 2, 3) to curate a specific list of People ordered by Last Name.

Includes:
- `tiamat-custom-entities` => `issue/tiamat-theme/466`
- `tiamat-theme` => `issue/tiamat-theme/466`

Resolves https://github.com/CuBoulder/tiamat-theme/issues/466