### PR TITLE
Fixed ordering of wysiwyg options

### DIFF
--- a/config/install/filter.format.wysiwyg.yml
+++ b/config/install/filter.format.wysiwyg.yml
@@ -17,6 +17,8 @@ dependencies:
     - editor
     - entity_embed
     - media
+    - shortcode
+    - ucb_ckeditor_plugins
 name: WYSIWYG
 format: wysiwyg
 weight: 0
@@ -33,13 +35,13 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <p class="text-align-left text-align-center text-align-right text-align-justify"> <h2 class="text-align-left text-align-center text-align-right text-align-justify"> <h3 class="text-align-left text-align-center text-align-right text-align-justify"> <h4 class="text-align-left text-align-center text-align-right text-align-justify"> <h5 class="text-align-left text-align-center text-align-right text-align-justify"> <h6 class="text-align-left text-align-center text-align-right text-align-justify"> <strong> <em> <sub> <sup> <blockquote> <a href> <ul> <ol reversed start> <li> <hr> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <tfoot> <caption> <drupal-media data-entity-type data-entity-uuid alt data-view-mode data-align> <abbr title class="ucb_tooltip">'
+      allowed_html: '<br> <p class="text-align-left text-align-center text-align-right"> <h2 class="text-align-left text-align-center text-align-right"> <h3 class="text-align-left text-align-center text-align-right"> <h4 class="text-align-left text-align-center text-align-right"> <h5 class="text-align-left text-align-center text-align-right"> <h6 class="text-align-left text-align-center text-align-right"> <strong> <em> <sub> <sup> <blockquote> <a href class="ucb-link-button ucb-link-button-blue ucb-link-button-black ucb-link-button-gray ucb-link-button-white ucb-link-button-large ucb-link-button-regular ucb-link-button-small ucb-link-button-full ucb-link-button-default ucb-link-button-gold"> <ul> <ol reversed start> <li> <hr> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <tfoot> <caption> <drupal-media data-entity-type data-entity-uuid alt data-view-mode data-align> <i class> <div class> <span class="sr-only ucb-link-button-contents"> <ucb-map class="ucb-map ucb-campus-map ucb-google-map ucb-map-size-small ucb-map-size-medium ucb-map-size-large" data-map-location> <ucb-calendar class="ucb-calendar ucb-google-calendar" data-query-string> <abbr title class="ucb-tooltip">'
       filter_html_help: true
       filter_html_nofollow: true
   filter_url:
     id: filter_url
     provider: filter
-    status: true
+    status: false
     weight: -48
     settings:
       filter_url_length: 72
@@ -107,4 +109,50 @@ filters:
     provider: filter
     status: true
     weight: -44
+    settings: {  }
+  shortcode:
+    id: shortcode
+    provider: shortcode
+    status: true
+    weight: 0
+    settings:
+      blockquote: '1'
+      box: '1'
+      buttongroup: '1'
+      button: '1'
+      callout: '1'
+      clear: '1'
+      close-margin: '1'
+      columnlist: '1'
+      column: '1'
+      countup: '1'
+      countdown: '1'
+      expand: '1'
+      give: '1'
+      googlecalendar: '1'
+      icon: '1'
+      imagecaption: '1'
+      invisible: '1'
+      listitem: '1'
+      map: '1'
+      masonry-images: '1'
+      print: '1'
+      responsive-table: '1'
+  shortcode_corrector:
+    id: shortcode_corrector
+    provider: shortcode
+    status: true
+    weight: 0
+    settings: {  }
+  filter_calendar_embed:
+    id: filter_calendar_embed
+    provider: ucb_ckeditor_plugins
+    status: true
+    weight: 10
+    settings: {  }
+  filter_map_embed:
+    id: filter_map_embed
+    provider: ucb_ckeditor_plugins
+    status: true
+    weight: 10
     settings: {  }


### PR DESCRIPTION
Closes https://github.com/CuBoulder/tiamat-theme/issues/503.
Fixes the ordering of the WYSIWYG Toolbar. The only remaining issue is the lack of the style tab, as we currently do not have any styles.