### PR TITLE
Resolves configuration conflict for Image Styles causing issues on the Admin Interface

### DIFF
--- a/config/install/image.style.wide_image_style.yml
+++ b/config/install/image.style.wide_image_style.yml
@@ -9,6 +9,6 @@ effects:
     id: image_scale_and_crop
     weight: 1
     data:
-      width: 900
-      height: 300
+      width: 1500
+      height: 563
       anchor: center-center


### PR DESCRIPTION
Resizes the `Wide` Image Style after fixing config.

Removes conflicting/duplicate `Image Style` configuration from `profile` that already existed in `custom-entities`, which caused the Admin interface to WSOD while trying to update the Image Styles via UI. 

Includes:
- `profile` => [`issue/tiamat-theme/524`](https://github.com/CuBoulder/tiamat10-profile/pull/40)
- `custom-entities` => [`issue/tiamat-theme/524` ](https://github.com/CuBoulder/tiamat-custom-entities/pull/82)

Resolves https://github.com/CuBoulder/tiamat-theme/issues/524