### PR TITLE
View Display fix on 'Focal Image Wide' + 'Focal Image Square' Image Styles on Sandbox Sites

### DIFF
--- a/config/install/core.entity_view_display.media.image.focal_image_square.yml
+++ b/config/install/core.entity_view_display.media.image.focal_image_square.yml
@@ -5,12 +5,11 @@ dependencies:
     - core.entity_view_mode.media.focal_image_square
     - field.field.media.image.field_media_image
     - field.field.media.image.field_media_image_caption
-    - image.style.media_library
+    - image.style.focal_image_square
     - media.type.image
   module:
     - image
     - layout_builder
-    - user
 third_party_settings:
   layout_builder:
     enabled: false
@@ -20,16 +19,6 @@ targetEntityType: media
 bundle: image
 mode: focal_image_square
 content:
-  created:
-    type: timestamp
-    label: hidden
-    settings:
-      date_format: medium
-      custom_date_format: ''
-      timezone: ''
-    third_party_settings: {  }
-    weight: 1
-    region: content
   field_media_image:
     type: image
     label: hidden
@@ -39,26 +28,11 @@ content:
       image_loading:
         attribute: lazy
     third_party_settings: {  }
-    weight: 2
-    region: content
-  thumbnail:
-    type: image
-    label: hidden
-    settings:
-      image_link: ''
-      image_style: media_library
-      image_loading:
-        attribute: lazy
-    third_party_settings: {  }
-    weight: 3
-    region: content
-  uid:
-    type: author
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
     weight: 0
     region: content
 hidden:
+  created: true
   field_media_image_caption: true
   name: true
+  thumbnail: true
+  uid: true

--- a/config/install/core.entity_view_display.media.image.focal_image_wide.yml
+++ b/config/install/core.entity_view_display.media.image.focal_image_wide.yml
@@ -5,12 +5,11 @@ dependencies:
     - core.entity_view_mode.media.focal_image_wide
     - field.field.media.image.field_media_image
     - field.field.media.image.field_media_image_caption
-    - image.style.media_library
+    - image.style.focal_image_wide
     - media.type.image
   module:
     - image
     - layout_builder
-    - user
 third_party_settings:
   layout_builder:
     enabled: false
@@ -20,16 +19,6 @@ targetEntityType: media
 bundle: image
 mode: focal_image_wide
 content:
-  created:
-    type: timestamp
-    label: hidden
-    settings:
-      date_format: medium
-      custom_date_format: ''
-      timezone: ''
-    third_party_settings: {  }
-    weight: 1
-    region: content
   field_media_image:
     type: image
     label: hidden
@@ -39,26 +28,11 @@ content:
       image_loading:
         attribute: lazy
     third_party_settings: {  }
-    weight: 2
-    region: content
-  thumbnail:
-    type: image
-    label: hidden
-    settings:
-      image_link: ''
-      image_style: media_library
-      image_loading:
-        attribute: lazy
-    third_party_settings: {  }
-    weight: 3
-    region: content
-  uid:
-    type: author
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
     weight: 0
     region: content
 hidden:
+  created: true
   field_media_image_caption: true
   name: true
+  thumbnail: true
+  uid: true


### PR DESCRIPTION
Changes view display configuration for 'Focal Image Wide' and 'Focal Image Square' to resolve the issue where unwanted fields would render with the styled image on sandbox sites.

Resolves https://github.com/CuBoulder/tiamat-theme/issues/521