### PR TITLE
Add help text to Calendar Block

### DIFF
--- a/config/install/block_content.type.events_calendar.yml
+++ b/config/install/block_content.type.events_calendar.yml
@@ -4,4 +4,4 @@ dependencies: {  }
 id: events_calendar
 label: 'Events Calendar'
 revision: 0
-description: 'Paragraph that allows event calendar embed code to be displayed.'
+description: 'Paragraph that allows event calendar embed code to be displayed. Widget Builder: <a href="https://calendar.colorado.edu/help/widget">https://calendar.colorado.edu/help/widget</a>'


### PR DESCRIPTION
Closes https://github.com/CuBoulder/tiamat-theme/issues/539.
Adds new help text to Calendar Block to link to the widget builder