### PR TITLE
Class Note + Class Note List Changes

### DIFF
--- a/config/install/core.entity_form_display.node.ucb_class_notes.default.yml
+++ b/config/install/core.entity_form_display.node.ucb_class_notes.default.yml
@@ -5,10 +5,9 @@ dependencies:
     - field.field.node.ucb_class_notes.body
     - field.field.node.ucb_class_notes.field_ucb_class_note_image
     - field.field.node.ucb_class_notes.field_ucb_class_year
-    - image.style.focal_image_square
     - node.type.ucb_class_notes
   module:
-    - image
+    - media_library
     - path
     - text
 id: node.ucb_class_notes.default
@@ -33,12 +32,11 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_ucb_class_note_image:
-    type: image_image
-    weight: 10
+    type: media_library_widget
+    weight: 26
     region: content
     settings:
-      progress_indicator: throbber
-      preview_image_style: focal_image_square
+      media_types: {  }
     third_party_settings: {  }
   field_ucb_class_year:
     type: options_select

--- a/config/install/core.entity_view_display.node.ucb_class_notes.default.yml
+++ b/config/install/core.entity_view_display.node.ucb_class_notes.default.yml
@@ -7,7 +7,6 @@ dependencies:
     - field.field.node.ucb_class_notes.field_ucb_class_year
     - node.type.ucb_class_notes
   module:
-    - image
     - options
     - text
     - user
@@ -24,15 +23,13 @@ content:
     weight: 1
     region: content
   field_ucb_class_note_image:
-    type: image
-    label: hidden
+    type: entity_reference_entity_view
+    label: above
     settings:
-      image_link: ''
-      image_style: ''
-      image_loading:
-        attribute: lazy
+      view_mode: default
+      link: false
     third_party_settings: {  }
-    weight: 2
+    weight: 4
     region: content
   field_ucb_class_year:
     type: list_default

--- a/config/install/field.field.node.ucb_class_notes.field_ucb_class_note_image.yml
+++ b/config/install/field.field.node.ucb_class_notes.field_ucb_class_note_image.yml
@@ -3,9 +3,8 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_ucb_class_note_image
+    - media.type.image
     - node.type.ucb_class_notes
-  module:
-    - image
 id: node.ucb_class_notes.field_ucb_class_note_image
 field_name: field_ucb_class_note_image
 entity_type: node
@@ -17,21 +16,13 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: 'default:file'
-  handler_settings: {  }
-  file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: 'png gif jpg jpeg'
-  max_filesize: ''
-  max_resolution: ''
-  min_resolution: ''
-  alt_field: true
-  alt_field_required: true
-  title_field: false
-  title_field_required: false
-  default_image:
-    uuid: ''
-    alt: ''
-    title: ''
-    width: null
-    height: null
-field_type: image
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.storage.node.field_ucb_class_note_image.yml
+++ b/config/install/field.storage.node.field_ucb_class_note_image.yml
@@ -2,25 +2,15 @@ langcode: en
 status: true
 dependencies:
   module:
-    - file
-    - image
+    - media
     - node
 id: node.field_ucb_class_note_image
 field_name: field_ucb_class_note_image
 entity_type: node
-type: image
+type: entity_reference
 settings:
-  target_type: file
-  display_field: false
-  display_default: false
-  uri_scheme: public
-  default_image:
-    uuid: ''
-    alt: ''
-    title: ''
-    width: null
-    height: null
-module: image
+  target_type: media
+module: core
 locked: false
 cardinality: -1
 translatable: true

--- a/config/install/field.storage.node.field_ucb_class_note_image.yml
+++ b/config/install/field.storage.node.field_ucb_class_note_image.yml
@@ -22,7 +22,7 @@ settings:
     height: null
 module: image
 locked: false
-cardinality: 1
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/install/node.type.ucb_class_notes.yml
+++ b/config/install/node.type.ucb_class_notes.yml
@@ -6,9 +6,8 @@ dependencies:
     - scheduler
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   scheduler:
     expand_fieldset: when_required
     fields_display_mode: vertical_tab

--- a/config/install/pathauto.pattern.ucb_class_note.yml
+++ b/config/install/pathauto.pattern.ucb_class_note.yml
@@ -6,12 +6,12 @@ dependencies:
 id: ucb_class_note
 label: 'UCB Class Note'
 type: 'canonical_entities:node'
-pattern: '/[node:title]'
+pattern: '/class-notes/[node:title]'
 selection_criteria:
-  d2a9a91e-0d3f-4e4f-98ea-5253fa9f6eb3:
+  8c62a636-ec67-4986-aa06-a3676d02b43d:
     id: 'entity_bundle:node'
     negate: false
-    uuid: d2a9a91e-0d3f-4e4f-98ea-5253fa9f6eb3
+    uuid: 8c62a636-ec67-4986-aa06-a3676d02b43d
     context_mapping:
       node: node
     bundles:

--- a/config/install/pathauto.pattern.ucb_class_notes_list.yml
+++ b/config/install/pathauto.pattern.ucb_class_notes_list.yml
@@ -6,12 +6,12 @@ dependencies:
 id: ucb_class_notes_list
 label: 'UCB Class Notes List'
 type: 'canonical_entities:node'
-pattern: '/[site:name]/classnotes'
+pattern: '/[site:name]/class-notes'
 selection_criteria:
-  7d5eb557-78c0-419f-87e6-41ed15549651:
+  91f15d02-f152-4a8f-80b1-b3ce4f712449:
     id: 'entity_bundle:node'
     negate: false
-    uuid: 7d5eb557-78c0-419f-87e6-41ed15549651
+    uuid: 91f15d02-f152-4a8f-80b1-b3ce4f712449
     context_mapping:
       node: node
     bundles:


### PR DESCRIPTION
- Adds images and adjusts the style of the `Class Notes List` page to mirror the Teaser-List display of other List-type nodes
- Allows for `Class Note` Content types to have multiple images (custom-entities)


Includes:

- `tiamat-theme` => https://github.com/CuBoulder/tiamat-theme/pull/657
- `tiamat-custom-entities` => https://github.com/CuBoulder/tiamat-custom-entities/pull/95

Resolves https://github.com/CuBoulder/tiamat-theme/issues/206