### PR TITLE
Content Row: Block Changes

### DIFF
--- a/config/install/block_content.type.content_row.yml
+++ b/config/install/block_content.type.content_row.yml
@@ -4,4 +4,4 @@ dependencies: {  }
 id: content_row
 label: 'Content Row'
 revision: 0
-description: "A paragraph that allows users to select different types of grid layouts to display content. \r\nTeasers\r\nTeasers Alternate\r\nTiles\r\nFeatures (3 cells Only)"
+description: "A paragraph that allows users to select different types of grid layouts to display content. \r\nTeaser\r\nLarge Teaser\r\nLarge Teaser Alternate\r\nTiles\r\nFeatures (3 cells Only)"

--- a/config/install/core.entity_form_display.block_content.content_row.default.yml
+++ b/config/install/core.entity_form_display.block_content.content_row.default.yml
@@ -12,8 +12,8 @@ third_party_settings:
   field_group:
     group_row_tabs:
       children:
-        - group_row_design
         - group_row_content
+        - group_row_design
       label: 'Row Tabs'
       region: content
       parent_name: ''
@@ -31,7 +31,7 @@ third_party_settings:
       label: 'Row Design'
       region: content
       parent_name: group_row_tabs
-      weight: 4
+      weight: 6
       format_type: tab
       format_settings:
         classes: ''

--- a/config/install/core.entity_form_display.block_content.content_row.default.yml
+++ b/config/install/core.entity_form_display.block_content.content_row.default.yml
@@ -37,7 +37,7 @@ third_party_settings:
         classes: ''
         show_empty_fields: false
         id: ''
-        formatter: open
+        formatter: closed
         description: ''
         required_fields: true
     group_row_content:
@@ -52,7 +52,7 @@ third_party_settings:
         classes: ''
         show_empty_fields: false
         id: ''
-        formatter: closed
+        formatter: open
         description: ''
         required_fields: true
 id: block_content.content_row.default

--- a/config/install/field.field.block_content.content_row.field_row_layout_content.yml
+++ b/config/install/field.field.block_content.content_row.field_row_layout_content.yml
@@ -12,7 +12,7 @@ field_name: field_row_layout_content
 entity_type: block_content
 bundle: content_row
 label: 'Row Layout Content'
-description: 'Add your row''s content here.'
+description: "Add your row's content here."
 required: false
 translatable: false
 default_value: {  }

--- a/config/install/field.storage.block_content.field_row_layout_selection.yml
+++ b/config/install/field.storage.block_content.field_row_layout_selection.yml
@@ -12,10 +12,13 @@ settings:
   allowed_values:
     -
       value: '0'
-      label: Teasers
+      label: Teaser
+    -
+      value: '4'
+      label: 'Large Teaser'
     -
       value: '1'
-      label: 'Teasers Alternate'
+      label: 'Large Teaser Alternate'
     -
       value: '2'
       label: Tiles


### PR DESCRIPTION
Adjusts the following on the `Content Row` blocks:
- On the "Configure Block" modal, switched the order of the tabs so 'Row Content' is on the left and open by default and 'Row Design' is on the right and hidden
- Added three teaser displays: `Large Teaser`, `Large Teaser Alternate`, and `Teaser`. Previously the teaser displays available were Teaser and Teaser Alternate.
- The `Large Teaser` and `Large Teaser Alternate` displays use the focal image wide style images rather than square.
- Adjusts style of the `Teaser` display to mirror other teaser-list style elements, such as the Article List. 
- Adjusted style of the `Tile` style display to more closely mirror the D7 version, which achieved the tile effect with images and text alternating. 
- Fixes bug where internal links, such as `/homepage` would cause a WSOD when added to Row Layout Content

Includes:
- `tiamat-theme` => https://github.com/CuBoulder/tiamat-theme/pull/687
- `custom-entities` => https://github.com/CuBoulder/tiamat-custom-entities/pull/99

Resolves https://github.com/CuBoulder/tiamat-theme/issues/673
Resolves https://github.com/CuBoulder/tiamat-theme/issues/674
Resolves https://github.com/CuBoulder/tiamat-theme/issues/675