### PR TITLE
Issue and Issue Archive use Media Library images

### DIFF
--- a/config/install/core.entity_form_display.node.ucb_issue.default.yml
+++ b/config/install/core.entity_form_display.node.ucb_issue.default.yml
@@ -6,10 +6,8 @@ dependencies:
     - field.field.node.ucb_issue.field_ucb_issue_image
     - field.field.node.ucb_issue.field_ucb_issue_secondary_image
     - field.field.node.ucb_issue.field_ucb_issue_section
-    - image.style.thumbnail
     - node.type.ucb_issue
   module:
-    - image
     - media_library
     - paragraphs
     - path
@@ -36,12 +34,11 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_ucb_issue_image:
-    type: image_image
+    type: media_library_widget
     weight: 9
     region: content
     settings:
-      progress_indicator: throbber
-      preview_image_style: thumbnail
+      media_types: {  }
     third_party_settings: {  }
   field_ucb_issue_secondary_image:
     type: media_library_widget
@@ -118,4 +115,11 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-hidden: {  }
+  url_redirects:
+    weight: 12
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  publish_on: true
+  unpublish_on: true

--- a/config/install/core.entity_form_display.node.ucb_issue.default.yml
+++ b/config/install/core.entity_form_display.node.ucb_issue.default.yml
@@ -3,7 +3,7 @@ status: true
 dependencies:
   config:
     - field.field.node.ucb_issue.body
-    - field.field.node.ucb_issue.field_ucb_issue_image
+    - field.field.node.ucb_issue.field_ucb_issue_cover_image
     - field.field.node.ucb_issue.field_ucb_issue_secondary_image
     - field.field.node.ucb_issue.field_ucb_issue_section
     - node.type.ucb_issue
@@ -33,7 +33,7 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_ucb_issue_image:
+  field_ucb_issue_cover_image:
     type: media_library_widget
     weight: 9
     region: content

--- a/config/install/core.entity_form_display.node.ucb_issue_archive.default.yml
+++ b/config/install/core.entity_form_display.node.ucb_issue_archive.default.yml
@@ -78,4 +78,11 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-hidden: {  }
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  publish_on: true
+  unpublish_on: true

--- a/config/install/core.entity_view_display.node.ucb_issue.default.yml
+++ b/config/install/core.entity_view_display.node.ucb_issue.default.yml
@@ -3,7 +3,7 @@ status: true
 dependencies:
   config:
     - field.field.node.ucb_issue.body
-    - field.field.node.ucb_issue.field_ucb_issue_image
+    - field.field.node.ucb_issue.field_ucb_issue_cover_image
     - field.field.node.ucb_issue.field_ucb_issue_secondary_image
     - field.field.node.ucb_issue.field_ucb_issue_section
     - node.type.ucb_issue
@@ -23,14 +23,14 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
-  field_ucb_issue_image:
+  field_ucb_issue_cover_image:
     type: entity_reference_entity_view
     label: hidden
     settings:
       view_mode: default
       link: false
     third_party_settings: {  }
-    weight: 2
+    weight: 1
     region: content
   field_ucb_issue_secondary_image:
     type: entity_reference_entity_view
@@ -39,7 +39,7 @@ content:
       view_mode: default
       link: false
     third_party_settings: {  }
-    weight: 3
+    weight: 2
     region: content
   field_ucb_issue_section:
     type: entity_reference_revisions_entity_view
@@ -48,7 +48,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 1
+    weight: 3
     region: content
 hidden:
   links: true

--- a/config/install/core.entity_view_display.node.ucb_issue.default.yml
+++ b/config/install/core.entity_view_display.node.ucb_issue.default.yml
@@ -9,7 +9,6 @@ dependencies:
     - node.type.ucb_issue
   module:
     - entity_reference_revisions
-    - image
     - text
     - user
 id: node.ucb_issue.default
@@ -25,15 +24,13 @@ content:
     weight: 0
     region: content
   field_ucb_issue_image:
-    type: image
+    type: entity_reference_entity_view
     label: hidden
     settings:
-      image_link: ''
-      image_style: ''
-      image_loading:
-        attribute: lazy
+      view_mode: default
+      link: false
     third_party_settings: {  }
-    weight: 1
+    weight: 2
     region: content
   field_ucb_issue_secondary_image:
     type: entity_reference_entity_view
@@ -51,7 +48,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 2
+    weight: 1
     region: content
 hidden:
   links: true

--- a/config/install/core.entity_view_display.node.ucb_issue.teaser.yml
+++ b/config/install/core.entity_view_display.node.ucb_issue.teaser.yml
@@ -4,7 +4,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.ucb_issue.body
-    - field.field.node.ucb_issue.field_ucb_issue_image
+    - field.field.node.ucb_issue.field_ucb_issue_cover_image
     - field.field.node.ucb_issue.field_ucb_issue_secondary_image
     - field.field.node.ucb_issue.field_ucb_issue_section
     - node.type.ucb_issue
@@ -30,6 +30,6 @@ content:
     weight: 100
     region: content
 hidden:
-  field_ucb_issue_image: true
+  field_ucb_issue_cover_image: true
   field_ucb_issue_secondary_image: true
   field_ucb_issue_section: true

--- a/config/install/field.field.node.ucb_issue.field_ucb_issue_cover_image.yml
+++ b/config/install/field.field.node.ucb_issue.field_ucb_issue_cover_image.yml
@@ -2,11 +2,11 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.field_ucb_issue_image
+    - field.storage.node.field_ucb_issue_cover_image
     - media.type.image
     - node.type.ucb_issue
-id: node.ucb_issue.field_ucb_issue_image
-field_name: field_ucb_issue_image
+id: node.ucb_issue.field_ucb_issue_cover_image
+field_name: field_ucb_issue_cover_image
 entity_type: node
 bundle: ucb_issue
 label: 'Issue Cover Image'

--- a/config/install/field.field.node.ucb_issue.field_ucb_issue_image.yml
+++ b/config/install/field.field.node.ucb_issue.field_ucb_issue_image.yml
@@ -3,35 +3,26 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_ucb_issue_image
+    - media.type.image
     - node.type.ucb_issue
-  module:
-    - image
 id: node.ucb_issue.field_ucb_issue_image
 field_name: field_ucb_issue_image
 entity_type: node
 bundle: ucb_issue
 label: 'Issue Cover Image'
-description: 'Upload an image to be used as a cover. This will display in the left column.'
+description: ''
 required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: 'default:file'
-  handler_settings: {  }
-  file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: 'png gif jpg jpeg'
-  max_filesize: ''
-  max_resolution: 640x480
-  min_resolution: ''
-  alt_field: true
-  alt_field_required: true
-  title_field: false
-  title_field_required: false
-  default_image:
-    uuid: ''
-    alt: ''
-    title: ''
-    width: null
-    height: null
-field_type: image
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.storage.node.field_ucb_issue_cover_image.yml
+++ b/config/install/field.storage.node.field_ucb_issue_cover_image.yml
@@ -4,8 +4,8 @@ dependencies:
   module:
     - media
     - node
-id: node.field_ucb_issue_image
-field_name: field_ucb_issue_image
+id: node.field_ucb_issue_cover_image
+field_name: field_ucb_issue_cover_image
 entity_type: node
 type: entity_reference
 settings:

--- a/config/install/field.storage.node.field_ucb_issue_image.yml
+++ b/config/install/field.storage.node.field_ucb_issue_image.yml
@@ -2,25 +2,15 @@ langcode: en
 status: true
 dependencies:
   module:
-    - file
-    - image
+    - media
     - node
 id: node.field_ucb_issue_image
 field_name: field_ucb_issue_image
 entity_type: node
-type: image
+type: entity_reference
 settings:
-  target_type: file
-  display_field: false
-  display_default: false
-  uri_scheme: public
-  default_image:
-    uuid: ''
-    alt: ''
-    title: ''
-    width: null
-    height: null
-module: image
+  target_type: media
+module: core
 locked: false
 cardinality: 1
 translatable: true


### PR DESCRIPTION
Changes the Issue cover image field to use the Media Library images rather than the default. This change requires creating an additional consumer in `Focal Image Enable` to use un-cropped image styles from JSON:API as well as modifying the Issue Archive build process to use that un-cropped image.

Includes:
- `tiamat-theme` => https://github.com/CuBoulder/tiamat-theme/pull/707
- `tiamat-custom-entities` =>  https://github.com/CuBoulder/tiamat-custom-entities/pull/105
- `ucb-focal-image-enable` => https://github.com/CuBoulder/ucb_focal_image_enable/pull/8

Resolves [#104 ](https://github.com/CuBoulder/tiamat-custom-entities/issues/104)