### PR TITLE
Removes requirement for Related Articles

### DIFF
--- a/config/install/field.field.node.ucb_article.field_ucb_related_articles_parag.yml
+++ b/config/install/field.field.node.ucb_article.field_ucb_related_articles_parag.yml
@@ -13,7 +13,7 @@ entity_type: node
 bundle: ucb_article
 label: 'Related Articles'
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
Related Articles block no longer required, which would cause errors on migrated sites with this block

Resolves #102 