### PR TITLE
Updates Collection Grid block

### DIFF
--- a/config/install/core.entity_form_display.block_content.collection_grid.default.yml
+++ b/config/install/core.entity_form_display.block_content.collection_grid.default.yml
@@ -107,6 +107,7 @@ third_party_settings:
       children:
         - group_block_styles
         - group_icon_settings
+        - group_block_heading
         - group_block_style
         - group_block_typography
       label: Styles
@@ -159,7 +160,7 @@ third_party_settings:
         - field_bs_heading_style
       label: 'Block Heading'
       region: content
-      parent_name: ''
+      parent_name: group_styles
       weight: 6
       format_type: tab
       format_settings:
@@ -213,7 +214,7 @@ content:
     third_party_settings: {  }
   field_bs_content_font_scale:
     type: options_select
-    weight: 11
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/install/field.field.block_content.collection_grid.field_collections_display.yml
+++ b/config/install/field.field.block_content.collection_grid.field_collections_display.yml
@@ -11,7 +11,7 @@ field_name: field_collections_display
 entity_type: block_content
 bundle: collection_grid
 label: 'Display Summary'
-description: 'You can choose whether or no to include a truncated version of body field text of the collection items.'
+description: 'You can choose whether or not to include a truncated version of body field text of the collection items.'
 required: true
 translatable: false
 default_value:


### PR DESCRIPTION
This update:
- [Bug] Fixes a minor typo in the description of the "Display Summary" field. Resolves CuBoulder/tiamat-custom-entities#122
- [Bug] Moves "Block Heading" into the correct place under the "Styles" tab in the form display.  Resolves CuBoulder/tiamat-custom-entities#121

Sister PR in: [tiamat-theme](https://github.com/CuBoulder/tiamat-theme/pull/851)