### PR TITLE
Remove Plain text from Collection Item Page

### DIFF
--- a/config/install/field.field.node.collection_item_page.field_collection_item_summary.yml
+++ b/config/install/field.field.node.collection_item_page.field_collection_item_summary.yml
@@ -23,5 +23,4 @@ settings:
   allowed_formats:
     - wysiwyg
     - full_html
-    - plain_text
 field_type: text_long


### PR DESCRIPTION
Closes https://github.com/CuBoulder/tiamat-theme/issues/928.
Removes the plain text option from the collection item page preview.