### PR TITLE
Removes menu_block:secondary config that causes warning

### DIFF
--- a/config/optional/core.entity_view_display.node.basic_page.default.yml
+++ b/config/optional/core.entity_view_display.node.basic_page.default.yml
@@ -94,26 +94,6 @@ third_party_settings:
               suggestion: main
             weight: 0
             additional: {  }
-          d0f3fe35-b443-4419-842c-4eee36066f93:
-            uuid: d0f3fe35-b443-4419-842c-4eee36066f93
-            region: second
-            configuration:
-              id: 'menu_block:secondary'
-              label: 'Secondary menu'
-              label_display: '0'
-              provider: menu_block
-              context_mapping: {  }
-              follow: false
-              follow_parent: child
-              label_link: false
-              label_type: block
-              level: 2
-              depth: 0
-              expand_all_items: false
-              parent: 'secondary:'
-              suggestion: secondary
-            weight: 1
-            additional: {  }
           33798309-27b1-4a55-9f74-f17591cf1d4f:
             uuid: 33798309-27b1-4a55-9f74-f17591cf1d4f
             region: second


### PR DESCRIPTION
Removes stray config in `core.entity_view_display.node.basic_page.default.yml` to remove the warnings when creating a dev environment.

Before:
![image](https://github.com/CuBoulder/tiamat-custom-entities/assets/85851903/f8985d9f-c338-4d2b-bcdf-71ffadb517ca)

After:
<img width="447" alt="Screenshot 2024-05-16 at 9 34 58 AM" src="https://github.com/CuBoulder/tiamat-custom-entities/assets/85851903/00767b8b-c6c6-4ecf-917f-b52e56930efe">

Resolves #140 