### PR TITLE
Updates form display of Content Sequence block

### DIFF
--- a/config/install/core.entity_form_display.block_content.content_sequence.default.yml
+++ b/config/install/core.entity_form_display.block_content.content_sequence.default.yml
@@ -29,7 +29,7 @@ third_party_settings:
       label: 'Content Sequence Tabs'
       region: content
       parent_name: ''
-      weight: 0
+      weight: 1
       format_type: tabs
       format_settings:
         classes: ''
@@ -155,16 +155,6 @@ targetEntityType: block_content
 bundle: content_sequence
 mode: default
 content:
-  body:
-    type: text_textarea_with_summary
-    weight: 1
-    region: content
-    settings:
-      rows: 9
-      summary_rows: 3
-      placeholder: ''
-      show_summary: false
-    third_party_settings: {  }
   field_bs_background_style:
     type: options_select
     weight: 12
@@ -245,6 +235,14 @@ content:
         collapse_edit_all: collapse_edit_all
         duplicate: duplicate
     third_party_settings: {  }
+  info:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
 hidden:
+  body: true
   field_content_sequence_display: true
-  info: true


### PR DESCRIPTION
This update includes two modifications to the Content Sequence block's form display:
- [Bug] Restores missing block info description for Content Sequence blocks added using Block Layout.
- [Remove] Removes stray description field previously used for the advanced Content Sequence. CuBoulder/tiamat-theme#934; Resolves CuBoulder/tiamat-custom-entities#142 