### PR TITLE
Image Styles: Adds 'Original Image Size' style, adjusts small

### DIFF
--- a/config/install/core.entity_view_display.media.image.original_image_size.yml
+++ b/config/install/core.entity_view_display.media.image.original_image_size.yml
@@ -1,0 +1,45 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.original_image_size
+    - field.field.media.image.field_media_image
+    - field.field.media.image.field_media_image_caption
+    - image.style.original_image_size
+    - media.type.image
+  module:
+    - image
+    - layout_builder
+    - text
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: media.image.original_image_size
+targetEntityType: media
+bundle: image
+mode: original_image_size
+content:
+  field_media_image:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: original_image_size
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_media_image_caption:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/install/core.entity_view_mode.media.original_image_size.yml
+++ b/config/install/core.entity_view_mode.media.original_image_size.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.original_image_size
+label: 'Original Image Size'
+description: ''
+targetEntityType: media
+cache: true

--- a/config/install/filter.format.full_html.yml
+++ b/config/install/filter.format.full_html.yml
@@ -7,39 +7,122 @@ dependencies:
     - core.entity_view_mode.media.large_image_style
     - core.entity_view_mode.media.media_library
     - core.entity_view_mode.media.medium_image_style
+    - core.entity_view_mode.media.original_image_size
     - core.entity_view_mode.media.small_image_style
     - core.entity_view_mode.media.small_square_image_style
     - core.entity_view_mode.media.square_thumbnail
     - core.entity_view_mode.media.wide_image_style
   module:
+    - ckeditor5_bootstrap_accordion
     - editor
     - entity_embed
+    - linkit
     - media
+    - ucb_ckeditor_plugins
 name: 'Full HTML'
 format: full_html
-weight: 1
+weight: -9
 filters:
+  editor_file_reference:
+    id: editor_file_reference
+    provider: editor
+    status: true
+    weight: -48
+    settings: {  }
+  entity_embed:
+    id: entity_embed
+    provider: entity_embed
+    status: false
+    weight: -37
+    settings: {  }
+  filter_align:
+    id: filter_align
+    provider: filter
+    status: true
+    weight: -50
+    settings: {  }
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: false
+    weight: -41
+    settings: {  }
+  filter_bootstrap_accordion:
+    id: filter_bootstrap_accordion
+    provider: ckeditor5_bootstrap_accordion
+    status: true
+    weight: -46
+    settings: {  }
+  filter_calendar_embed:
+    id: filter_calendar_embed
+    provider: ucb_ckeditor_plugins
+    status: true
+    weight: -44
+    settings: {  }
+  filter_caption:
+    id: filter_caption
+    provider: filter
+    status: false
+    weight: -40
+    settings: {  }
   filter_html:
     id: filter_html
     provider: filter
     status: false
-    weight: -50
+    weight: -43
     settings:
       allowed_html: ''
       filter_html_help: true
       filter_html_nofollow: false
+  filter_html_escape:
+    id: filter_html_escape
+    provider: filter
+    status: false
+    weight: -42
+    settings: {  }
+  filter_html_image_secure:
+    id: filter_html_image_secure
+    provider: filter
+    status: false
+    weight: -38
+    settings: {  }
+  filter_htmlcorrector:
+    id: filter_htmlcorrector
+    provider: filter
+    status: true
+    weight: -49
+    settings: {  }
+  filter_image_lazy_load:
+    id: filter_image_lazy_load
+    provider: filter
+    status: false
+    weight: -33
+    settings: {  }
+  filter_map_embed:
+    id: filter_map_embed
+    provider: ucb_ckeditor_plugins
+    status: true
+    weight: -45
+    settings: {  }
   filter_url:
     id: filter_url
     provider: filter
     status: false
-    weight: -43
+    weight: -39
     settings:
       filter_url_length: 72
+  linkit:
+    id: linkit
+    provider: linkit
+    status: false
+    weight: -36
+    settings:
+      title: true
   media_embed:
     id: media_embed
     provider: media
     status: true
-    weight: -40
+    weight: -47
     settings:
       default_view_mode: media_library
       allowed_view_modes:
@@ -48,6 +131,7 @@ filters:
         large_image_style: large_image_style
         media_library: media_library
         medium_image_style: medium_image_style
+        original_image_size: original_image_size
         small_image_style: small_image_style
         small_square_image_style: small_square_image_style
         square_thumbnail: square_thumbnail
@@ -55,51 +139,3 @@ filters:
       allowed_media_types:
         image: image
         video: video
-  filter_align:
-    id: filter_align
-    provider: filter
-    status: true
-    weight: -48
-    settings: {  }
-  filter_htmlcorrector:
-    id: filter_htmlcorrector
-    provider: filter
-    status: true
-    weight: -47
-    settings: {  }
-  editor_file_reference:
-    id: editor_file_reference
-    provider: editor
-    status: true
-    weight: -46
-    settings: {  }
-  entity_embed:
-    id: entity_embed
-    provider: entity_embed
-    status: false
-    weight: -41
-    settings: {  }
-  filter_autop:
-    id: filter_autop
-    provider: filter
-    status: false
-    weight: -45
-    settings: {  }
-  filter_caption:
-    id: filter_caption
-    provider: filter
-    status: false
-    weight: -44
-    settings: {  }
-  filter_html_escape:
-    id: filter_html_escape
-    provider: filter
-    status: false
-    weight: -49
-    settings: {  }
-  filter_html_image_secure:
-    id: filter_html_image_secure
-    provider: filter
-    status: false
-    weight: -42
-    settings: {  }

--- a/config/install/filter.format.wysiwyg.yml
+++ b/config/install/filter.format.wysiwyg.yml
@@ -9,23 +9,63 @@ dependencies:
     - core.entity_view_mode.media.large_image_style
     - core.entity_view_mode.media.media_library
     - core.entity_view_mode.media.medium_image_style
+    - core.entity_view_mode.media.original_image_size
     - core.entity_view_mode.media.small_image_style
     - core.entity_view_mode.media.small_square_image_style
     - core.entity_view_mode.media.square_thumbnail
     - core.entity_view_mode.media.wide_image_style
   module:
+    - ckeditor5_bootstrap_accordion
     - editor
     - entity_embed
+    - linkit
     - media
+    - ucb_ckeditor_plugins
 name: WYSIWYG
 format: wysiwyg
-weight: 0
+weight: -10
 filters:
+  editor_file_reference:
+    id: editor_file_reference
+    provider: editor
+    status: false
+    weight: -36
+    settings: {  }
   entity_embed:
     id: entity_embed
     provider: entity_embed
     status: true
-    weight: -41
+    weight: -46
+    settings: {  }
+  filter_align:
+    id: filter_align
+    provider: filter
+    status: true
+    weight: -47
+    settings: {  }
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: false
+    weight: -35
+    settings: {  }
+  filter_bootstrap_accordion:
+    id: filter_bootstrap_accordion
+    provider: ckeditor5_bootstrap_accordion
+    status: true
+    weight: -42
+    settings: {  }
+  filter_calendar_embed:
+    id: filter_calendar_embed
+    provider: ucb_ckeditor_plugins
+    status: true
+    weight: -39
+    settings: {  }
+  filter_caption:
+    id: filter_caption
+    provider: filter
+    status: false
+    weight: -34
     settings: {  }
   filter_html:
     id: filter_html
@@ -33,21 +73,58 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <p class="text-align-left text-align-center text-align-right text-align-justify"> <h2 class="text-align-left text-align-center text-align-right text-align-justify"> <h3 class="text-align-left text-align-center text-align-right text-align-justify"> <h4 class="text-align-left text-align-center text-align-right text-align-justify"> <h5 class="text-align-left text-align-center text-align-right text-align-justify"> <h6 class="text-align-left text-align-center text-align-right text-align-justify"> <strong> <em> <sub> <sup> <blockquote> <a href> <ul> <ol reversed start> <li> <hr> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <tfoot> <caption> <drupal-media data-entity-type data-entity-uuid alt data-view-mode data-align> <abbr title class="ucb_tooltip">'
+      allowed_html: '<a id target rel class="ck-anchor accordion-button collapsed ucb-link-button ucb-link-button-blue ucb-link-button-black ucb-link-button-gray ucb-link-button-white ucb-link-button-large ucb-link-button-regular ucb-link-button-small ucb-link-button-full ucb-link-button-default ucb-link-button-gold" href data-entity-type data-entity-uuid data-entity-substitution> <br> <p class="lead hero supersize small-text text-align-left text-align-center text-align-right"> <h2 class="text-align-left text-align-center text-align-right"> <h3 class="text-align-left text-align-center text-align-right"> <h4 class="text-align-left text-align-center text-align-right"> <h5 class="text-align-left text-align-center text-align-right"> <h6 class="text-align-left text-align-center text-align-right"> <span class="small-text visually-hidden ucb-link-button-contents ucb-countup counter ucb-countdown countdown-full countdown-solid countdown-transparent countdown-inline countdown-stacked" aria-hidden="true"> <ul class="column-list column-list-2 column-list-3 column-list-4 list-style-underline list-style-nobullet list-style-border"> <ol class="list-style-alpha-upper list-style-alpha-lower list-style-roman-upper list-style-roman-lower column-list column-list-2 column-list-3 column-list-4" reversed start> <table class="table-zebra table-condensed table-small table-vertical table-horizontal"> <strong> <em> <sub> <sup> <blockquote> <li> <hr> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <tfoot> <caption> <drupal-media data-entity-type data-entity-uuid alt data-view-mode data-align> <div data-accordion-id class> <i class> <ucb-map class="ucb-map ucb-campus-map ucb-google-map ucb-map-size-small ucb-map-size-medium ucb-map-size-large" data-map-location> <ucb-calendar class="ucb-calendar ucb-google-calendar" data-query-string> <ucb-jump-menu headertag data-title> <drupal-entity alt title data-align data-caption data-entity-embed-display data-entity-embed-display-settings data-view-mode data-entity-uuid data-langcode data-embed-button="node" data-entity-type="node">'
       filter_html_help: true
       filter_html_nofollow: true
-  filter_url:
-    id: filter_url
+  filter_html_escape:
+    id: filter_html_escape
+    provider: filter
+    status: false
+    weight: -38
+    settings: {  }
+  filter_html_image_secure:
+    id: filter_html_image_secure
+    provider: filter
+    status: true
+    weight: -49
+    settings: {  }
+  filter_htmlcorrector:
+    id: filter_htmlcorrector
     provider: filter
     status: true
     weight: -48
+    settings: {  }
+  filter_image_lazy_load:
+    id: filter_image_lazy_load
+    provider: filter
+    status: false
+    weight: -33
+    settings: {  }
+  filter_map_embed:
+    id: filter_map_embed
+    provider: ucb_ckeditor_plugins
+    status: true
+    weight: -40
+    settings: {  }
+  filter_url:
+    id: filter_url
+    provider: filter
+    status: false
+    weight: -37
     settings:
       filter_url_length: 72
+  linkit:
+    id: linkit
+    provider: linkit
+    status: true
+    weight: -43
+    settings:
+      title: true
   media_embed:
     id: media_embed
     provider: media
     status: true
-    weight: -40
+    weight: -45
     settings:
       default_view_mode: default
       allowed_view_modes:
@@ -59,6 +136,7 @@ filters:
         large_image_style: large_image_style
         media_library: media_library
         medium_image_style: medium_image_style
+        original_image_size: original_image_size
         small_image_style: small_image_style
         small_square_image_style: small_square_image_style
         square_thumbnail: square_thumbnail
@@ -66,45 +144,3 @@ filters:
       allowed_media_types:
         image: image
         video: video
-  filter_html_escape:
-    id: filter_html_escape
-    provider: filter
-    status: false
-    weight: -49
-    settings: {  }
-  filter_align:
-    id: filter_align
-    provider: filter
-    status: true
-    weight: -42
-    settings: {  }
-  filter_htmlcorrector:
-    id: filter_htmlcorrector
-    provider: filter
-    status: true
-    weight: -43
-    settings: {  }
-  editor_file_reference:
-    id: editor_file_reference
-    provider: editor
-    status: false
-    weight: -47
-    settings: {  }
-  filter_autop:
-    id: filter_autop
-    provider: filter
-    status: false
-    weight: -46
-    settings: {  }
-  filter_caption:
-    id: filter_caption
-    provider: filter
-    status: false
-    weight: -45
-    settings: {  }
-  filter_html_image_secure:
-    id: filter_html_image_secure
-    provider: filter
-    status: true
-    weight: -44
-    settings: {  }

--- a/config/install/image.style.original_image_size.yml
+++ b/config/install/image.style.original_image_size.yml
@@ -1,0 +1,6 @@
+langcode: en
+status: true
+dependencies: {  }
+name: original_image_size
+label: 'Original Image Size'
+effects: {  }

--- a/config/install/image.style.small_500px_25_display_size_.yml
+++ b/config/install/image.style.small_500px_25_display_size_.yml
@@ -2,13 +2,13 @@ langcode: en
 status: true
 dependencies: {  }
 name: small_500px_25_display_size_
-label: 'Small (500px, 25% display size)'
+label: 'Small (375px, 25% display size)'
 effects:
   3d01fad5-7b8f-40c7-8194-457e71c1a75f:
     uuid: 3d01fad5-7b8f-40c7-8194-457e71c1a75f
     id: image_scale
     weight: 1
     data:
-      width: 500
+      width: 375
       height: null
       upscale: true


### PR DESCRIPTION
### Image Styles
- Adds new 'Original Image Size' image style to WYSIWYG and Full HTML
- Adjusts the 'Small' Image Size to be 375px wide, mirroring D7. Previously this was set to 500px.

Includes:
- `tiamat-custom-entities` => https://github.com/CuBoulder/tiamat-custom-entities/pull/155
- `tiamat-profile` => https://github.com/CuBoulder/tiamat10-profile/pull/177


Resolves #154 