### PR TITLE
Slate Form: Allows a Block Description & Config Fixes

### DIFF
--- a/config/install/core.entity_form_display.block_content.ucb_slate_form.default.yml
+++ b/config/install/core.entity_form_display.block_content.ucb_slate_form.default.yml
@@ -39,12 +39,13 @@ third_party_settings:
         width_breakpoint: 640
     group_content:
       children:
+        - info
         - field_ucb_slate_form_id
         - field_ucb_slate_form_domain
       label: Content
       region: content
       parent_name: group_tabs
-      weight: 2
+      weight: 1
       format_type: tab
       format_settings:
         classes: ''
@@ -63,7 +64,7 @@ third_party_settings:
       label: Styles
       region: content
       parent_name: group_tabs
-      weight: 3
+      weight: 2
       format_type: tab
       format_settings:
         classes: ''
@@ -188,7 +189,7 @@ content:
     third_party_settings: {  }
   field_bs_icon:
     type: text_textarea
-    weight: 2
+    weight: 1
     region: content
     settings:
       rows: 1
@@ -196,19 +197,19 @@ content:
     third_party_settings: {  }
   field_bs_icon_color:
     type: options_select
-    weight: 4
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
   field_bs_icon_position:
     type: options_select
-    weight: 3
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
   field_bs_icon_size:
     type: options_select
-    weight: 6
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -220,13 +221,21 @@ content:
     third_party_settings: {  }
   field_ucb_slate_form_domain:
     type: link_default
-    weight: 1
+    weight: 2
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
   field_ucb_slate_form_id:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  info:
     type: string_textfield
     weight: 0
     region: content
@@ -236,4 +245,3 @@ content:
     third_party_settings: {  }
 hidden:
   body: true
-  info: true

--- a/config/install/core.entity_form_display.block_content.ucb_slate_form.default.yml
+++ b/config/install/core.entity_form_display.block_content.ucb_slate_form.default.yml
@@ -74,8 +74,7 @@ third_party_settings:
         description: ''
         required_fields: true
     group_block_styles:
-      children:
-        - field_bs_background_style
+      children: {  }
       label: 'Block Styles'
       region: content
       parent_name: group_styles
@@ -123,7 +122,8 @@ third_party_settings:
         description: ''
         required_fields: true
     group_block_style:
-      children: {  }
+      children:
+        - field_bs_background_style
       label: 'Block Style'
       region: content
       parent_name: group_styles

--- a/config/install/filter.format.full_html.yml
+++ b/config/install/filter.format.full_html.yml
@@ -13,116 +13,34 @@ dependencies:
     - core.entity_view_mode.media.square_thumbnail
     - core.entity_view_mode.media.wide_image_style
   module:
-    - ckeditor5_bootstrap_accordion
     - editor
     - entity_embed
-    - linkit
     - media
-    - ucb_ckeditor_plugins
 name: 'Full HTML'
 format: full_html
-weight: -9
+weight: 1
 filters:
-  editor_file_reference:
-    id: editor_file_reference
-    provider: editor
-    status: true
-    weight: -48
-    settings: {  }
-  entity_embed:
-    id: entity_embed
-    provider: entity_embed
-    status: false
-    weight: -37
-    settings: {  }
-  filter_align:
-    id: filter_align
-    provider: filter
-    status: true
-    weight: -50
-    settings: {  }
-  filter_autop:
-    id: filter_autop
-    provider: filter
-    status: false
-    weight: -41
-    settings: {  }
-  filter_bootstrap_accordion:
-    id: filter_bootstrap_accordion
-    provider: ckeditor5_bootstrap_accordion
-    status: true
-    weight: -46
-    settings: {  }
-  filter_calendar_embed:
-    id: filter_calendar_embed
-    provider: ucb_ckeditor_plugins
-    status: true
-    weight: -44
-    settings: {  }
-  filter_caption:
-    id: filter_caption
-    provider: filter
-    status: false
-    weight: -40
-    settings: {  }
   filter_html:
     id: filter_html
     provider: filter
     status: false
-    weight: -43
+    weight: -50
     settings:
       allowed_html: ''
       filter_html_help: true
       filter_html_nofollow: false
-  filter_html_escape:
-    id: filter_html_escape
-    provider: filter
-    status: false
-    weight: -42
-    settings: {  }
-  filter_html_image_secure:
-    id: filter_html_image_secure
-    provider: filter
-    status: false
-    weight: -38
-    settings: {  }
-  filter_htmlcorrector:
-    id: filter_htmlcorrector
-    provider: filter
-    status: true
-    weight: -49
-    settings: {  }
-  filter_image_lazy_load:
-    id: filter_image_lazy_load
-    provider: filter
-    status: false
-    weight: -33
-    settings: {  }
-  filter_map_embed:
-    id: filter_map_embed
-    provider: ucb_ckeditor_plugins
-    status: true
-    weight: -45
-    settings: {  }
   filter_url:
     id: filter_url
     provider: filter
     status: false
-    weight: -39
+    weight: -43
     settings:
       filter_url_length: 72
-  linkit:
-    id: linkit
-    provider: linkit
-    status: false
-    weight: -36
-    settings:
-      title: true
   media_embed:
     id: media_embed
     provider: media
     status: true
-    weight: -47
+    weight: -40
     settings:
       default_view_mode: media_library
       allowed_view_modes:
@@ -139,3 +57,51 @@ filters:
       allowed_media_types:
         image: image
         video: video
+  filter_align:
+    id: filter_align
+    provider: filter
+    status: true
+    weight: -48
+    settings: {  }
+  filter_htmlcorrector:
+    id: filter_htmlcorrector
+    provider: filter
+    status: true
+    weight: -47
+    settings: {  }
+  editor_file_reference:
+    id: editor_file_reference
+    provider: editor
+    status: true
+    weight: -46
+    settings: {  }
+  entity_embed:
+    id: entity_embed
+    provider: entity_embed
+    status: false
+    weight: -41
+    settings: {  }
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: false
+    weight: -45
+    settings: {  }
+  filter_caption:
+    id: filter_caption
+    provider: filter
+    status: false
+    weight: -44
+    settings: {  }
+  filter_html_escape:
+    id: filter_html_escape
+    provider: filter
+    status: false
+    weight: -49
+    settings: {  }
+  filter_html_image_secure:
+    id: filter_html_image_secure
+    provider: filter
+    status: false
+    weight: -42
+    settings: {  }

--- a/config/install/filter.format.wysiwyg.yml
+++ b/config/install/filter.format.wysiwyg.yml
@@ -15,57 +15,18 @@ dependencies:
     - core.entity_view_mode.media.square_thumbnail
     - core.entity_view_mode.media.wide_image_style
   module:
-    - ckeditor5_bootstrap_accordion
     - editor
     - entity_embed
-    - linkit
     - media
-    - ucb_ckeditor_plugins
 name: WYSIWYG
 format: wysiwyg
-weight: -10
+weight: 0
 filters:
-  editor_file_reference:
-    id: editor_file_reference
-    provider: editor
-    status: false
-    weight: -36
-    settings: {  }
   entity_embed:
     id: entity_embed
     provider: entity_embed
     status: true
-    weight: -46
-    settings: {  }
-  filter_align:
-    id: filter_align
-    provider: filter
-    status: true
-    weight: -47
-    settings: {  }
-  filter_autop:
-    id: filter_autop
-    provider: filter
-    status: false
-    weight: -35
-    settings: {  }
-  filter_bootstrap_accordion:
-    id: filter_bootstrap_accordion
-    provider: ckeditor5_bootstrap_accordion
-    status: true
-    weight: -42
-    settings: {  }
-  filter_calendar_embed:
-    id: filter_calendar_embed
-    provider: ucb_ckeditor_plugins
-    status: true
-    weight: -39
-    settings: {  }
-  filter_caption:
-    id: filter_caption
-    provider: filter
-    status: false
-    weight: -34
+    weight: -41
     settings: {  }
   filter_html:
     id: filter_html
@@ -73,58 +34,21 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<a id target rel class="ck-anchor accordion-button collapsed ucb-link-button ucb-link-button-blue ucb-link-button-black ucb-link-button-gray ucb-link-button-white ucb-link-button-large ucb-link-button-regular ucb-link-button-small ucb-link-button-full ucb-link-button-default ucb-link-button-gold" href data-entity-type data-entity-uuid data-entity-substitution> <br> <p class="lead hero supersize small-text text-align-left text-align-center text-align-right"> <h2 class="text-align-left text-align-center text-align-right"> <h3 class="text-align-left text-align-center text-align-right"> <h4 class="text-align-left text-align-center text-align-right"> <h5 class="text-align-left text-align-center text-align-right"> <h6 class="text-align-left text-align-center text-align-right"> <span class="small-text visually-hidden ucb-link-button-contents ucb-countup counter ucb-countdown countdown-full countdown-solid countdown-transparent countdown-inline countdown-stacked" aria-hidden="true"> <ul class="column-list column-list-2 column-list-3 column-list-4 list-style-underline list-style-nobullet list-style-border"> <ol class="list-style-alpha-upper list-style-alpha-lower list-style-roman-upper list-style-roman-lower column-list column-list-2 column-list-3 column-list-4" reversed start> <table class="table-zebra table-condensed table-small table-vertical table-horizontal"> <strong> <em> <sub> <sup> <blockquote> <li> <hr> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <tfoot> <caption> <drupal-media data-entity-type data-entity-uuid alt data-view-mode data-align> <div data-accordion-id class> <i class> <ucb-map class="ucb-map ucb-campus-map ucb-google-map ucb-map-size-small ucb-map-size-medium ucb-map-size-large" data-map-location> <ucb-calendar class="ucb-calendar ucb-google-calendar" data-query-string> <ucb-jump-menu headertag data-title> <drupal-entity alt title data-align data-caption data-entity-embed-display data-entity-embed-display-settings data-view-mode data-entity-uuid data-langcode data-embed-button="node" data-entity-type="node">'
+      allowed_html: '<br> <p class="text-align-left text-align-center text-align-right text-align-justify"> <h2 class="text-align-left text-align-center text-align-right text-align-justify"> <h3 class="text-align-left text-align-center text-align-right text-align-justify"> <h4 class="text-align-left text-align-center text-align-right text-align-justify"> <h5 class="text-align-left text-align-center text-align-right text-align-justify"> <h6 class="text-align-left text-align-center text-align-right text-align-justify"> <strong> <em> <sub> <sup> <blockquote> <a href> <ul> <ol reversed start> <li> <hr> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <tfoot> <caption> <drupal-media data-entity-type data-entity-uuid alt data-view-mode data-align> <abbr title class="ucb_tooltip">'
       filter_html_help: true
       filter_html_nofollow: true
-  filter_html_escape:
-    id: filter_html_escape
-    provider: filter
-    status: false
-    weight: -38
-    settings: {  }
-  filter_html_image_secure:
-    id: filter_html_image_secure
-    provider: filter
-    status: true
-    weight: -49
-    settings: {  }
-  filter_htmlcorrector:
-    id: filter_htmlcorrector
-    provider: filter
-    status: true
-    weight: -48
-    settings: {  }
-  filter_image_lazy_load:
-    id: filter_image_lazy_load
-    provider: filter
-    status: false
-    weight: -33
-    settings: {  }
-  filter_map_embed:
-    id: filter_map_embed
-    provider: ucb_ckeditor_plugins
-    status: true
-    weight: -40
-    settings: {  }
   filter_url:
     id: filter_url
     provider: filter
-    status: false
-    weight: -37
+    status: true
+    weight: -48
     settings:
       filter_url_length: 72
-  linkit:
-    id: linkit
-    provider: linkit
-    status: true
-    weight: -43
-    settings:
-      title: true
   media_embed:
     id: media_embed
     provider: media
     status: true
-    weight: -45
+    weight: -40
     settings:
       default_view_mode: default
       allowed_view_modes:
@@ -144,3 +68,45 @@ filters:
       allowed_media_types:
         image: image
         video: video
+  filter_html_escape:
+    id: filter_html_escape
+    provider: filter
+    status: false
+    weight: -49
+    settings: {  }
+  filter_align:
+    id: filter_align
+    provider: filter
+    status: true
+    weight: -42
+    settings: {  }
+  filter_htmlcorrector:
+    id: filter_htmlcorrector
+    provider: filter
+    status: true
+    weight: -43
+    settings: {  }
+  editor_file_reference:
+    id: editor_file_reference
+    provider: editor
+    status: false
+    weight: -47
+    settings: {  }
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: false
+    weight: -46
+    settings: {  }
+  filter_caption:
+    id: filter_caption
+    provider: filter
+    status: false
+    weight: -45
+    settings: {  }
+  filter_html_image_secure:
+    id: filter_html_image_secure
+    provider: filter
+    status: true
+    weight: -44
+    settings: {  }


### PR DESCRIPTION
### Slate Form
Enables a hidden Block Description so users can add in information to make their reuseable block more easily identifiable when going to `/admin/content`

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1171

### Dev Config Fix
A previously commit broke some config in `filter.format` files for wysiwyg and full html, preventing devs from reinstalling via `lando install-site`.  This has been corrected.

Related: https://github.com/CuBoulder/tiamat-theme/pull/1182