### PR TITLE
Hides "End Date" fields from Content Sequence items

### DIFF
--- a/config/install/core.entity_form_display.paragraph.content_sequence_item.default.yml
+++ b/config/install/core.entity_form_display.paragraph.content_sequence_item.default.yml
@@ -24,11 +24,10 @@ third_party_settings:
         - group_sequence_title
         - group_content
         - group_sequence_date
-        - group_sequence_group
       label: 'Content Sequence Step Tabs'
       region: content
       parent_name: ''
-      weight: 9
+      weight: 1
       format_type: tabs
       format_settings:
         classes: ''
@@ -70,8 +69,8 @@ third_party_settings:
         required_fields: true
     group_sequence_date:
       children:
-        - group_date_details
-        - group_end_date_details
+        - field_sequence_item_d_start_date
+        - field_sequence_item_start_date
       label: Date
       region: content
       parent_name: group_content_sequence_step_tabs
@@ -84,54 +83,14 @@ third_party_settings:
         formatter: closed
         description: ''
         required_fields: true
-    group_date_details:
-      children:
-        - field_sequence_item_start_date
-        - field_sequence_item_d_start_date
-      label: 'Start Date'
-      region: content
-      parent_name: group_sequence_date
-      weight: 6
-      format_type: details
-      format_settings:
-        classes: ''
-        show_empty_fields: false
-        id: ''
-        open: false
-        description: ''
-        required_fields: true
-    group_end_date_details:
-      children:
-        - field_sequence_item_end_date
-        - field_sequence_item_d_end_date
-      label: 'End Date'
-      region: content
-      parent_name: group_sequence_date
-      weight: 9
-      format_type: details
-      format_settings:
-        classes: ''
-        show_empty_fields: false
-        id: ''
-        open: false
-        description: ''
-        required_fields: true
 id: paragraph.content_sequence_item.default
 targetEntityType: paragraph
 bundle: content_sequence_item
 mode: default
 content:
-  field_sequence_item_d_end_date:
-    type: string_textfield
-    weight: 8
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
   field_sequence_item_d_start_date:
     type: string_textfield
-    weight: 5
+    weight: 0
     region: content
     settings:
       size: 60
@@ -145,12 +104,6 @@ content:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
-  field_sequence_item_end_date:
-    type: datetime_default
-    weight: 17
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   field_sequence_item_media:
     type: media_library_widget
     weight: 3
@@ -160,7 +113,7 @@ content:
     third_party_settings: {  }
   field_sequence_item_start_date:
     type: datetime_default
-    weight: 16
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -182,4 +135,6 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_sequence_item_d_end_date: true
+  field_sequence_item_end_date: true
   status: true

--- a/config/install/field.field.paragraph.content_sequence_item.field_sequence_item_d_start_date.yml
+++ b/config/install/field.field.paragraph.content_sequence_item.field_sequence_item_d_start_date.yml
@@ -8,7 +8,7 @@ id: paragraph.content_sequence_item.field_sequence_item_d_start_date
 field_name: field_sequence_item_d_start_date
 entity_type: paragraph
 bundle: content_sequence_item
-label: 'Item Display Start Date'
+label: 'Display date'
 description: ''
 required: false
 translatable: false

--- a/config/install/field.field.paragraph.content_sequence_item.field_sequence_item_start_date.yml
+++ b/config/install/field.field.paragraph.content_sequence_item.field_sequence_item_start_date.yml
@@ -10,8 +10,8 @@ id: paragraph.content_sequence_item.field_sequence_item_start_date
 field_name: field_sequence_item_start_date
 entity_type: paragraph
 bundle: content_sequence_item
-label: 'Start date'
-description: 'The starting date of the content sequence item. This field is required for advanced content sequences.'
+label: Date
+description: 'The date of the content sequence item.'
 required: false
 translatable: false
 default_value: {  }


### PR DESCRIPTION
These fields aren't currently used anywhere and do nothing. This update hides them.

[remove] Resolves CuBoulder/tiamat-custom-entities#158