### PR TITLE
New Image Styles: Colorbox Image Styles

### DIFF
--- a/config/install/core.entity_view_display.media.image.colorbox_small.yml
+++ b/config/install/core.entity_view_display.media.image.colorbox_small.yml
@@ -1,0 +1,48 @@
+uuid: 0b987eda-bca4-47f0-a859-092e1b635767
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.colorbox_small
+    - field.field.media.image.field_media_image
+    - field.field.media.image.field_media_image_caption
+    - image.style.colorbox_small
+    - media.type.image
+  module:
+    - image
+    - layout_builder
+    - text
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+_core:
+  default_config_hash: DPQF7FpejmJUfV4hf2yaf_0JlDpTAojB9_lOIX2Zq6I
+id: media.image.colorbox_small
+targetEntityType: media
+bundle: image
+mode: colorbox_small
+content:
+  field_media_image:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: colorbox_small
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_media_image_caption:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/install/core.entity_view_display.media.image.colorbox_small_square.yml
+++ b/config/install/core.entity_view_display.media.image.colorbox_small_square.yml
@@ -1,0 +1,48 @@
+uuid: 7a3c7d21-5cd9-46b9-a2e8-29468185d944
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.colorbox_small_square
+    - field.field.media.image.field_media_image
+    - field.field.media.image.field_media_image_caption
+    - image.style.colorbox_small_square
+    - media.type.image
+  module:
+    - image
+    - layout_builder
+    - text
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+_core:
+  default_config_hash: DPQF7FpejmJUfV4hf2yaf_0JlDpTAojB9_lOIX2Zq6I
+id: media.image.colorbox_small_square
+targetEntityType: media
+bundle: image
+mode: colorbox_small_square
+content:
+  field_media_image:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: colorbox_small_square
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_media_image_caption:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/install/core.entity_view_display.media.image.colorbox_small_thumbnail.yml
+++ b/config/install/core.entity_view_display.media.image.colorbox_small_thumbnail.yml
@@ -1,0 +1,48 @@
+uuid: cb517783-4716-4596-b210-c54a71976dc9
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.colorbox_small_thumbnail
+    - field.field.media.image.field_media_image
+    - field.field.media.image.field_media_image_caption
+    - image.style.colorbox_small_thumbnail
+    - media.type.image
+  module:
+    - image
+    - layout_builder
+    - text
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+_core:
+  default_config_hash: DPQF7FpejmJUfV4hf2yaf_0JlDpTAojB9_lOIX2Zq6I
+id: media.image.colorbox_small_thumbnail
+targetEntityType: media
+bundle: image
+mode: colorbox_small_thumbnail
+content:
+  field_media_image:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: colorbox_small_thumbnail
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_media_image_caption:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/install/core.entity_view_display.media.image.colorbox_square.yml
+++ b/config/install/core.entity_view_display.media.image.colorbox_square.yml
@@ -1,0 +1,48 @@
+uuid: 8466d973-7512-4fa0-9354-171bf3b61b6d
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.colorbox_square
+    - field.field.media.image.field_media_image
+    - field.field.media.image.field_media_image_caption
+    - image.style.colorbox_square
+    - media.type.image
+  module:
+    - image
+    - layout_builder
+    - text
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+_core:
+  default_config_hash: DPQF7FpejmJUfV4hf2yaf_0JlDpTAojB9_lOIX2Zq6I
+id: media.image.colorbox_square
+targetEntityType: media
+bundle: image
+mode: colorbox_square
+content:
+  field_media_image:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: colorbox_square
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_media_image_caption:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/install/core.entity_view_mode.media.colorbox_small.yml
+++ b/config/install/core.entity_view_mode.media.colorbox_small.yml
@@ -1,0 +1,11 @@
+uuid: 2941c28c-a1da-4317-8419-d99bbee345b6
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.colorbox_small
+label: 'Colorbox Small'
+description: 'Width is sized to 300 pixels; lightbox added.'
+targetEntityType: media
+cache: true

--- a/config/install/core.entity_view_mode.media.colorbox_small_square.yml
+++ b/config/install/core.entity_view_mode.media.colorbox_small_square.yml
@@ -1,0 +1,11 @@
+uuid: a671f23e-9cdd-4453-8e4c-084c49b0da8d
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.colorbox_small_square
+label: 'Colorbox Small - Square'
+description: 'Image cropped to a tiny square, 70 pixels per side; lightbox added.'
+targetEntityType: media
+cache: true

--- a/config/install/core.entity_view_mode.media.colorbox_small_thumbnail.yml
+++ b/config/install/core.entity_view_mode.media.colorbox_small_thumbnail.yml
@@ -1,0 +1,11 @@
+uuid: 8625db82-6342-468c-9c10-6cb571017794
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.colorbox_small_thumbnail
+label: 'Colorbox Small - Thumbnail'
+description: 'Image width is sized to 100 pixels; lightbox added.'
+targetEntityType: media
+cache: true

--- a/config/install/core.entity_view_mode.media.colorbox_square.yml
+++ b/config/install/core.entity_view_mode.media.colorbox_square.yml
@@ -1,0 +1,11 @@
+uuid: a1f845c8-c283-4836-bb7f-c37b7c4e5a60
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.colorbox_square
+label: 'Colorbox Square'
+description: 'Image cropped to a square, 180 pixels per side; lightbox added. '
+targetEntityType: media
+cache: true

--- a/config/install/filter.format.full_html.yml
+++ b/config/install/filter.format.full_html.yml
@@ -2,6 +2,10 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.media.colorbox_small
+    - core.entity_view_mode.media.colorbox_small_square
+    - core.entity_view_mode.media.colorbox_small_thumbnail
+    - core.entity_view_mode.media.colorbox_square
     - core.entity_view_mode.media.focal_image_square
     - core.entity_view_mode.media.focal_image_wide
     - core.entity_view_mode.media.large_image_style
@@ -44,6 +48,10 @@ filters:
     settings:
       default_view_mode: media_library
       allowed_view_modes:
+        colorbox_small: colorbox_small
+        colorbox_small_square: colorbox_small_square
+        colorbox_small_thumbnail: colorbox_small_thumbnail
+        colorbox_square: colorbox_square
         focal_image_square: focal_image_square
         focal_image_wide: focal_image_wide
         large_image_style: large_image_style

--- a/config/install/filter.format.wysiwyg.yml
+++ b/config/install/filter.format.wysiwyg.yml
@@ -2,6 +2,10 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.media.colorbox_small
+    - core.entity_view_mode.media.colorbox_small_square
+    - core.entity_view_mode.media.colorbox_small_thumbnail
+    - core.entity_view_mode.media.colorbox_square
     - core.entity_view_mode.media.editor_embed_image
     - core.entity_view_mode.media.focal_image_square
     - core.entity_view_mode.media.focal_image_wide
@@ -53,6 +57,10 @@ filters:
       default_view_mode: default
       allowed_view_modes:
         default: default
+        colorbox_small: colorbox_small
+        colorbox_small_square: colorbox_small_square
+        colorbox_small_thumbnail: colorbox_small_thumbnail
+        colorbox_square: colorbox_square
         editor_embed_image: editor_embed_image
         focal_image_square: focal_image_square
         focal_image_wide: focal_image_wide

--- a/config/install/image.style.colorbox_small.yml
+++ b/config/install/image.style.colorbox_small.yml
@@ -1,0 +1,15 @@
+uuid: d24d4992-67bf-4ac1-9bf9-ee9a7d173f8f
+langcode: en
+status: true
+dependencies: {  }
+name: colorbox_small
+label: 'Colorbox Small'
+effects:
+  69caf9d2-c3f8-4107-8826-4254793e6090:
+    uuid: 69caf9d2-c3f8-4107-8826-4254793e6090
+    id: image_scale
+    weight: 1
+    data:
+      width: 300
+      height: null
+      upscale: false

--- a/config/install/image.style.colorbox_small_square.yml
+++ b/config/install/image.style.colorbox_small_square.yml
@@ -1,0 +1,15 @@
+uuid: 3a02faa8-eb99-41c6-b66d-77d7fdf062d6
+langcode: en
+status: true
+dependencies: {  }
+name: colorbox_small_square
+label: 'Colorbox Small - Square'
+effects:
+  0957c5ee-c7a4-48c1-95ac-d63693062253:
+    uuid: 0957c5ee-c7a4-48c1-95ac-d63693062253
+    id: image_crop
+    weight: 1
+    data:
+      width: 70
+      height: 70
+      anchor: center-center

--- a/config/install/image.style.colorbox_small_thumbnail.yml
+++ b/config/install/image.style.colorbox_small_thumbnail.yml
@@ -1,0 +1,15 @@
+uuid: 582e608b-1384-4fb0-b488-6dbf5996b8ad
+langcode: en
+status: true
+dependencies: {  }
+name: colorbox_small_thumbnail
+label: 'Colorbox Small - Thumbnail'
+effects:
+  49440330-9e93-47ee-8fe6-5affd078d575:
+    uuid: 49440330-9e93-47ee-8fe6-5affd078d575
+    id: image_scale
+    weight: 1
+    data:
+      width: 100
+      height: null
+      upscale: false

--- a/config/install/image.style.colorbox_square.yml
+++ b/config/install/image.style.colorbox_square.yml
@@ -1,0 +1,15 @@
+uuid: 7797e62a-3967-462c-9ad0-0f885d2d5b0d
+langcode: en
+status: true
+dependencies: {  }
+name: colorbox_square
+label: 'Colorbox Square'
+effects:
+  fc5b2ad7-0c69-4d9e-abe0-ea308bfdc080:
+    uuid: fc5b2ad7-0c69-4d9e-abe0-ea308bfdc080
+    id: image_crop
+    weight: 1
+    data:
+      width: 180
+      height: 180
+      anchor: center-center


### PR DESCRIPTION
Adds config files for Colorbox style images

### New Image Styles
Adds 4 new colorbox image styles: `Colorbox Small` , `Colorbox Small Square`, `Colorbox Small Thumbnail`, `Colorbox Square`. On click, these open up a modal with the full image and caption.

Includes:

- `tiamat-theme` => https://github.com/CuBoulder/tiamat-theme/pull/1205
- `tiamat-custom-entities` => https://github.com/CuBoulder/tiamat-custom-entities/pull/160
- `tiamat-profile` => https://github.com/CuBoulder/tiamat10-profile/pull/185

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1174