### PR TITLE
'Small Square' Image Style size adjustments

### DIFF
--- a/config/install/image.style.small_square_image_style.yml
+++ b/config/install/image.style.small_square_image_style.yml
@@ -2,13 +2,13 @@ langcode: en
 status: true
 dependencies: {  }
 name: small_square_image_style
-label: 'Small Square (500 x 500, 25% display size)'
+label: 'Small Square (375 x 375, 25% display size)'
 effects:
   0804ead2-325d-4756-844f-0c9d1b0d3c79:
     uuid: 0804ead2-325d-4756-844f-0c9d1b0d3c79
     id: image_scale_and_crop
     weight: 1
     data:
-      width: 500
-      height: 500
+      width: 375
+      height: 375
       anchor: center-center


### PR DESCRIPTION
### Image Style: Small Square
Adjusts the `Small Square` image style size to mirror the `Small` image style sizing, reducing the width from 500px to 375px. 

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1222