### PR TITLE
New Image styles issue/1240

### DIFF
--- a/config/install/core.entity_view_display.paragraph.slider_image.default.yml
+++ b/config/install/core.entity_view_display.paragraph.slider_image.default.yml
@@ -19,7 +19,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: focal_image_wide
+      view_mode: original_image_size
       link: false
     third_party_settings: {  }
     weight: 0

--- a/config/install/field.storage.block_content.field_slider_size.yml
+++ b/config/install/field.storage.block_content.field_slider_size.yml
@@ -18,10 +18,10 @@ settings:
       label: 'Widescreen - 1600x900'
     -
       value: '2'
-      label: '3:2 - 1500x500'
+      label: 'Large 3:2 - 1500x1000'
     -
       value: '3'
-      label: Large
+      label: 'Original'
   allowed_values_function: ''
 module: options
 locked: false

--- a/config/install/image.style.slider_3_2.yml
+++ b/config/install/image.style.slider_3_2.yml
@@ -1,0 +1,17 @@
+uuid: d4e3cff8-6c37-4a7a-b711-d31a6d3d375e
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: slider_3_2
+label: 'Slider 3:2'
+effects:
+  772c7b9a-e377-4b52-998f-cfc8adad5685:
+    uuid: 772c7b9a-e377-4b52-998f-cfc8adad5685
+    id: focal_point_scale_and_crop
+    weight: 1
+    data:
+      width: 1500
+      height: 1000
+      crop_type: focal_point

--- a/config/install/image.style.slider_ultrawide.yml
+++ b/config/install/image.style.slider_ultrawide.yml
@@ -1,0 +1,17 @@
+uuid: 9be1a3e6-bed7-4ddd-b409-76a16d57107a
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: slider_ultrawide
+label: 'Slider Ultrawide'
+effects:
+  4e7c1679-0505-4e91-8bef-3aa81b8f218f:
+    uuid: 4e7c1679-0505-4e91-8bef-3aa81b8f218f
+    id: focal_point_scale_and_crop
+    weight: 1
+    data:
+      width: 1600
+      height: 600
+      crop_type: focal_point

--- a/config/install/image.style.slider_widescreen.yml
+++ b/config/install/image.style.slider_widescreen.yml
@@ -1,0 +1,17 @@
+uuid: bca0077d-4b12-494a-ac61-5dd28d6172e8
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: slider_widescreen
+label: 'Slider Widescreen'
+effects:
+  381fe7f4-2db0-4f21-8979-8f2cd7c7ed9f:
+    uuid: 381fe7f4-2db0-4f21-8979-8f2cd7c7ed9f
+    id: focal_point_scale_and_crop
+    weight: 1
+    data:
+      width: 1600
+      height: 900
+      crop_type: focal_point


### PR DESCRIPTION
Added three new image styles:
Slider Ultrawide (1600x600)
Slider Widescreen (1600:900)
Slider 3:2 (1500:1000)

Each style has the proper sizing dictated by Kevin
The Slider block has been updated to have the proper names and sizes associated with them.
The slide paragraph now has the default image style set to Original.
The slider block template has had it's sizing logic moved to the paragraph slide template.
The paragraph slide template uses parent logic to check what side the slider is going to be and applies the appropriate style to each image.

Sister PR: https://github.com/CuBoulder/tiamat-theme/pull/1252

Closes #1240 