### PR TITLE
Article thumbnail style change 

### DIFF
--- a/config/install/core.entity_view_display.node.ucb_article.default.yml
+++ b/config/install/core.entity_view_display.node.ucb_article.default.yml
@@ -142,7 +142,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: default
+      view_mode: focal_image_wide
       link: false
     third_party_settings: {  }
     weight: 1


### PR DESCRIPTION
This is a change to the article's thumbnail display so that cropping works properly across our various blocks.
This is one of several incoming changes for issue #1249
https://github.com/CuBoulder/tiamat-theme/issues/1249