### PR TITLE
Adds the Faculty Publications block

### DIFF
--- a/config/install/block_content.type.faculty_publications.yml
+++ b/config/install/block_content.type.faculty_publications.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: faculty_publications
+label: 'Faculty Publications'
+revision: 0
+description: 'Provides a list of publications authored or co-authored by faculty members. Publications are sourced from <a target="_blank" href="https://experts.colorado.edu/">CU Experts</a>.'

--- a/config/install/core.entity_form_display.block_content.faculty_publications.default.yml
+++ b/config/install/core.entity_form_display.block_content.faculty_publications.default.yml
@@ -1,0 +1,275 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.faculty_publications
+    - field.field.block_content.faculty_publications.field_bs_background_style
+    - field.field.block_content.faculty_publications.field_bs_content_font_scale
+    - field.field.block_content.faculty_publications.field_bs_heading
+    - field.field.block_content.faculty_publications.field_bs_heading_alignment
+    - field.field.block_content.faculty_publications.field_bs_heading_style
+    - field.field.block_content.faculty_publications.field_bs_icon
+    - field.field.block_content.faculty_publications.field_bs_icon_color
+    - field.field.block_content.faculty_publications.field_bs_icon_position
+    - field.field.block_content.faculty_publications.field_bs_icon_size
+    - field.field.block_content.faculty_publications.field_bs_title_font_scale
+    - field.field.block_content.faculty_publications.field_faculty_publications_dpt
+    - field.field.block_content.faculty_publications.field_faculty_publications_email
+    - field.field.block_content.faculty_publications.field_faculty_publications_from
+    - field.field.block_content.faculty_publications.field_faculty_publications_to
+  module:
+    - datetime
+    - field_group
+    - text
+third_party_settings:
+  field_group:
+    group_content:
+      children:
+        - group_publication_date
+        - field_faculty_publications_dpt
+        - field_faculty_publications_email
+      label: Content
+      region: content
+      parent_name: group_tabs
+      weight: 1
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_styles:
+      children:
+        - group_block_styles
+        - group_block_icon
+        - group_block_heading
+        - group_block_style
+        - group_block_typography
+      label: Styles
+      region: content
+      parent_name: group_tabs
+      weight: 2
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_block_styles:
+      children: {  }
+      label: 'Block Styles'
+      region: content
+      parent_name: group_styles
+      weight: 20
+      format_type: tabs
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        direction: vertical
+        width_breakpoint: 640
+    group_block_icon:
+      children:
+        - field_bs_icon
+        - field_bs_icon_position
+        - field_bs_icon_color
+        - field_bs_icon_size
+      label: 'Block Icon'
+      region: content
+      parent_name: group_styles
+      weight: 20
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_block_style:
+      children:
+        - field_bs_background_style
+      label: 'Block Style'
+      region: content
+      parent_name: group_styles
+      weight: 21
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_block_heading:
+      children:
+        - field_bs_heading
+        - field_bs_heading_alignment
+        - field_bs_heading_style
+      label: 'Block Heading'
+      region: content
+      parent_name: group_styles
+      weight: 20
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_block_typography:
+      children:
+        - field_bs_title_font_scale
+        - field_bs_content_font_scale
+      label: 'Block Typography'
+      region: content
+      parent_name: group_styles
+      weight: 22
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_tabs:
+      children:
+        - group_content
+        - group_styles
+      label: Tabs
+      region: content
+      parent_name: ''
+      weight: 0
+      format_type: tabs
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        direction: horizontal
+        width_breakpoint: 640
+    group_publication_date:
+      children:
+        - field_faculty_publications_from
+        - field_faculty_publications_to
+      label: 'Publication date'
+      region: content
+      parent_name: group_content
+      weight: 1
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        description: ''
+        required_fields: true
+id: block_content.faculty_publications.default
+targetEntityType: block_content
+bundle: faculty_publications
+mode: default
+content:
+  field_bs_background_style:
+    type: options_select
+    weight: 12
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_bs_content_font_scale:
+    type: options_select
+    weight: 11
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_bs_heading:
+    type: options_select
+    weight: 7
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_bs_heading_alignment:
+    type: options_select
+    weight: 8
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_bs_heading_style:
+    type: options_select
+    weight: 9
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_bs_icon:
+    type: text_textarea
+    weight: 2
+    region: content
+    settings:
+      rows: 1
+      placeholder: ''
+    third_party_settings: {  }
+  field_bs_icon_color:
+    type: options_select
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_bs_icon_position:
+    type: options_select
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_bs_icon_size:
+    type: options_select
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_bs_title_font_scale:
+    type: options_select
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_faculty_publications_dpt:
+    type: string_textfield
+    weight: 4
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_faculty_publications_email:
+    type: email_default
+    weight: 5
+    region: content
+    settings:
+      placeholder: ''
+      size: 60
+    third_party_settings: {  }
+  field_faculty_publications_from:
+    type: datetime_default
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_faculty_publications_to:
+    type: datetime_default
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  info:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/config/install/core.entity_form_display.block_content.faculty_publications.default.yml
+++ b/config/install/core.entity_form_display.block_content.faculty_publications.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.block_content.faculty_publications.field_bs_icon_position
     - field.field.block_content.faculty_publications.field_bs_icon_size
     - field.field.block_content.faculty_publications.field_bs_title_font_scale
+    - field.field.block_content.faculty_publications.field_faculty_publications_auto
     - field.field.block_content.faculty_publications.field_faculty_publications_count
     - field.field.block_content.faculty_publications.field_faculty_publications_dpt
     - field.field.block_content.faculty_publications.field_faculty_publications_email
@@ -30,8 +31,8 @@ third_party_settings:
     group_content:
       children:
         - group_publication_date
-        - group_on_this_site
         - group_custom
+        - group_on_this_site
       label: Filters
       region: content
       parent_name: group_tabs
@@ -167,12 +168,13 @@ third_party_settings:
       region: content
       parent_name: group_content
       weight: 9
-      format_type: fieldset
+      format_type: details
       format_settings:
         classes: ''
         show_empty_fields: false
         id: ''
         label_as_html: false
+        open: true
         description: ''
         required_fields: true
     group_sort:
@@ -196,10 +198,10 @@ third_party_settings:
       children:
         - field_faculty_publications_p
         - field_faculty_publications_jt
-      label: 'On this site'
+      label: 'Authors – On this site'
       region: content
       parent_name: group_content
-      weight: 10
+      weight: 11
       format_type: details
       format_settings:
         classes: ''
@@ -207,16 +209,17 @@ third_party_settings:
         id: ''
         label_as_html: false
         open: true
-        description: 'Select from faculty members on this site. The faculty member''s primary email address must match the one on <a target="_blank" href="https://experts.colorado.edu/people">CU Experts</a> or no publications will be returned. Choosing multiple people will include results matching any one person.'
+        description: 'Select from faculty members on this site. The faculty member''s primary email address must match the one on <a target="_blank" href="https://experts.colorado.edu/people">CU Experts</a> or no publications will be returned. Choosing multiple people will include results matching one or more people.'
         required_fields: true
     group_custom:
       children:
         - field_faculty_publications_dpt
         - field_faculty_publications_email
-      label: Custom
+        - field_faculty_publications_auto
+      label: 'Authors – Custom'
       region: content
       parent_name: group_content
-      weight: 11
+      weight: 10
       format_type: details
       format_settings:
         classes: ''
@@ -293,6 +296,13 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_faculty_publications_auto:
+    type: boolean_checkbox
+    weight: 12
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_faculty_publications_count:
     type: options_select
     weight: 27
@@ -309,7 +319,7 @@ content:
     third_party_settings: {  }
   field_faculty_publications_email:
     type: email_default
-    weight: 12
+    weight: 11
     region: content
     settings:
       placeholder: ''

--- a/config/install/core.entity_form_display.block_content.faculty_publications.default.yml
+++ b/config/install/core.entity_form_display.block_content.faculty_publications.default.yml
@@ -13,9 +13,13 @@ dependencies:
     - field.field.block_content.faculty_publications.field_bs_icon_position
     - field.field.block_content.faculty_publications.field_bs_icon_size
     - field.field.block_content.faculty_publications.field_bs_title_font_scale
+    - field.field.block_content.faculty_publications.field_faculty_publications_count
     - field.field.block_content.faculty_publications.field_faculty_publications_dpt
     - field.field.block_content.faculty_publications.field_faculty_publications_email
     - field.field.block_content.faculty_publications.field_faculty_publications_from
+    - field.field.block_content.faculty_publications.field_faculty_publications_jt
+    - field.field.block_content.faculty_publications.field_faculty_publications_p
+    - field.field.block_content.faculty_publications.field_faculty_publications_sort
     - field.field.block_content.faculty_publications.field_faculty_publications_to
   module:
     - datetime
@@ -26,9 +30,9 @@ third_party_settings:
     group_content:
       children:
         - group_publication_date
-        - field_faculty_publications_dpt
-        - field_faculty_publications_email
-      label: Content
+        - group_on_this_site
+        - group_custom
+      label: Filters
       region: content
       parent_name: group_tabs
       weight: 1
@@ -37,6 +41,7 @@ third_party_settings:
         classes: ''
         show_empty_fields: false
         id: ''
+        label_as_html: false
         formatter: closed
         description: ''
         required_fields: true
@@ -50,7 +55,7 @@ third_party_settings:
       label: Styles
       region: content
       parent_name: group_tabs
-      weight: 2
+      weight: 3
       format_type: tab
       format_settings:
         classes: ''
@@ -141,6 +146,7 @@ third_party_settings:
     group_tabs:
       children:
         - group_content
+        - group_sort
         - group_styles
       label: Tabs
       region: content
@@ -160,7 +166,7 @@ third_party_settings:
       label: 'Publication date'
       region: content
       parent_name: group_content
-      weight: 1
+      weight: 9
       format_type: fieldset
       format_settings:
         classes: ''
@@ -169,6 +175,57 @@ third_party_settings:
         label_as_html: false
         description: ''
         required_fields: true
+    group_sort:
+      children:
+        - field_faculty_publications_count
+        - field_faculty_publications_sort
+      label: Display
+      region: content
+      parent_name: group_tabs
+      weight: 2
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        formatter: closed
+        description: ''
+        required_fields: false
+    group_on_this_site:
+      children:
+        - field_faculty_publications_p
+        - field_faculty_publications_jt
+      label: 'On this site'
+      region: content
+      parent_name: group_content
+      weight: 10
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        open: true
+        description: 'Select from faculty members on this site. The faculty member''s primary email address must match the one on <a target="_blank" href="https://experts.colorado.edu/people">CU Experts</a> or no publications will be returned. Choosing multiple people will include results matching any one person.'
+        required_fields: true
+    group_custom:
+      children:
+        - field_faculty_publications_dpt
+        - field_faculty_publications_email
+      label: Custom
+      region: content
+      parent_name: group_content
+      weight: 11
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        open: true
+        description: ''
+        required_fields: false
 id: block_content.faculty_publications.default
 targetEntityType: block_content
 bundle: faculty_publications
@@ -236,9 +293,15 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_faculty_publications_count:
+    type: options_select
+    weight: 27
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_faculty_publications_dpt:
     type: string_textfield
-    weight: 4
+    weight: 10
     region: content
     settings:
       size: 60
@@ -246,7 +309,7 @@ content:
     third_party_settings: {  }
   field_faculty_publications_email:
     type: email_default
-    weight: 5
+    weight: 12
     region: content
     settings:
       placeholder: ''
@@ -255,6 +318,28 @@ content:
   field_faculty_publications_from:
     type: datetime_default
     weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_faculty_publications_jt:
+    type: options_buttons
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_faculty_publications_p:
+    type: entity_reference_autocomplete
+    weight: 29
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_faculty_publications_sort:
+    type: options_select
+    weight: 28
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/install/core.entity_view_display.block_content.faculty_publications.default.yml
+++ b/config/install/core.entity_view_display.block_content.faculty_publications.default.yml
@@ -13,9 +13,13 @@ dependencies:
     - field.field.block_content.faculty_publications.field_bs_icon_position
     - field.field.block_content.faculty_publications.field_bs_icon_size
     - field.field.block_content.faculty_publications.field_bs_title_font_scale
+    - field.field.block_content.faculty_publications.field_faculty_publications_count
     - field.field.block_content.faculty_publications.field_faculty_publications_dpt
     - field.field.block_content.faculty_publications.field_faculty_publications_email
     - field.field.block_content.faculty_publications.field_faculty_publications_from
+    - field.field.block_content.faculty_publications.field_faculty_publications_jt
+    - field.field.block_content.faculty_publications.field_faculty_publications_p
+    - field.field.block_content.faculty_publications.field_faculty_publications_sort
     - field.field.block_content.faculty_publications.field_faculty_publications_to
   module:
     - datetime
@@ -96,6 +100,13 @@ content:
     third_party_settings: {  }
     weight: 13
     region: content
+  field_faculty_publications_count:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 15
+    region: content
   field_faculty_publications_dpt:
     type: string
     label: above
@@ -119,6 +130,29 @@ content:
       format_type: medium
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_faculty_publications_jt:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 17
+    region: content
+  field_faculty_publications_p:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 16
+    region: content
+  field_faculty_publications_sort:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 14
     region: content
   field_faculty_publications_to:
     type: datetime_default

--- a/config/install/core.entity_view_display.block_content.faculty_publications.default.yml
+++ b/config/install/core.entity_view_display.block_content.faculty_publications.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.block_content.faculty_publications.field_bs_icon_position
     - field.field.block_content.faculty_publications.field_bs_icon_size
     - field.field.block_content.faculty_publications.field_bs_title_font_scale
+    - field.field.block_content.faculty_publications.field_faculty_publications_auto
     - field.field.block_content.faculty_publications.field_faculty_publications_count
     - field.field.block_content.faculty_publications.field_faculty_publications_dpt
     - field.field.block_content.faculty_publications.field_faculty_publications_email
@@ -99,6 +100,16 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 13
+    region: content
+  field_faculty_publications_auto:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 18
     region: content
   field_faculty_publications_count:
     type: list_default

--- a/config/install/core.entity_view_display.block_content.faculty_publications.default.yml
+++ b/config/install/core.entity_view_display.block_content.faculty_publications.default.yml
@@ -1,0 +1,132 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.faculty_publications
+    - field.field.block_content.faculty_publications.field_bs_background_style
+    - field.field.block_content.faculty_publications.field_bs_content_font_scale
+    - field.field.block_content.faculty_publications.field_bs_heading
+    - field.field.block_content.faculty_publications.field_bs_heading_alignment
+    - field.field.block_content.faculty_publications.field_bs_heading_style
+    - field.field.block_content.faculty_publications.field_bs_icon
+    - field.field.block_content.faculty_publications.field_bs_icon_color
+    - field.field.block_content.faculty_publications.field_bs_icon_position
+    - field.field.block_content.faculty_publications.field_bs_icon_size
+    - field.field.block_content.faculty_publications.field_bs_title_font_scale
+    - field.field.block_content.faculty_publications.field_faculty_publications_dpt
+    - field.field.block_content.faculty_publications.field_faculty_publications_email
+    - field.field.block_content.faculty_publications.field_faculty_publications_from
+    - field.field.block_content.faculty_publications.field_faculty_publications_to
+  module:
+    - datetime
+    - options
+    - text
+id: block_content.faculty_publications.default
+targetEntityType: block_content
+bundle: faculty_publications
+mode: default
+content:
+  field_bs_background_style:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_bs_content_font_scale:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  field_bs_heading:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 6
+    region: content
+  field_bs_heading_alignment:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 7
+    region: content
+  field_bs_heading_style:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 8
+    region: content
+  field_bs_icon:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 9
+    region: content
+  field_bs_icon_color:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 10
+    region: content
+  field_bs_icon_position:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 11
+    region: content
+  field_bs_icon_size:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 12
+    region: content
+  field_bs_title_font_scale:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 13
+    region: content
+  field_faculty_publications_dpt:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_faculty_publications_email:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_faculty_publications_from:
+    type: datetime_default
+    label: above
+    settings:
+      timezone_override: ''
+      format_type: medium
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_faculty_publications_to:
+    type: datetime_default
+    label: above
+    settings:
+      timezone_override: ''
+      format_type: medium
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden: {  }

--- a/config/install/core.entity_view_display.media.image.colorbox_small.yml
+++ b/config/install/core.entity_view_display.media.image.colorbox_small.yml
@@ -1,4 +1,3 @@
-uuid: 0b987eda-bca4-47f0-a859-092e1b635767
 langcode: en
 status: true
 dependencies:
@@ -16,8 +15,6 @@ third_party_settings:
   layout_builder:
     enabled: false
     allow_custom: false
-_core:
-  default_config_hash: DPQF7FpejmJUfV4hf2yaf_0JlDpTAojB9_lOIX2Zq6I
 id: media.image.colorbox_small
 targetEntityType: media
 bundle: image

--- a/config/install/core.entity_view_display.media.image.colorbox_small_square.yml
+++ b/config/install/core.entity_view_display.media.image.colorbox_small_square.yml
@@ -1,4 +1,3 @@
-uuid: 7a3c7d21-5cd9-46b9-a2e8-29468185d944
 langcode: en
 status: true
 dependencies:
@@ -16,8 +15,6 @@ third_party_settings:
   layout_builder:
     enabled: false
     allow_custom: false
-_core:
-  default_config_hash: DPQF7FpejmJUfV4hf2yaf_0JlDpTAojB9_lOIX2Zq6I
 id: media.image.colorbox_small_square
 targetEntityType: media
 bundle: image

--- a/config/install/core.entity_view_display.media.image.colorbox_small_thumbnail.yml
+++ b/config/install/core.entity_view_display.media.image.colorbox_small_thumbnail.yml
@@ -1,4 +1,3 @@
-uuid: cb517783-4716-4596-b210-c54a71976dc9
 langcode: en
 status: true
 dependencies:
@@ -16,8 +15,6 @@ third_party_settings:
   layout_builder:
     enabled: false
     allow_custom: false
-_core:
-  default_config_hash: DPQF7FpejmJUfV4hf2yaf_0JlDpTAojB9_lOIX2Zq6I
 id: media.image.colorbox_small_thumbnail
 targetEntityType: media
 bundle: image

--- a/config/install/core.entity_view_display.media.image.colorbox_square.yml
+++ b/config/install/core.entity_view_display.media.image.colorbox_square.yml
@@ -1,4 +1,3 @@
-uuid: 8466d973-7512-4fa0-9354-171bf3b61b6d
 langcode: en
 status: true
 dependencies:
@@ -16,8 +15,6 @@ third_party_settings:
   layout_builder:
     enabled: false
     allow_custom: false
-_core:
-  default_config_hash: DPQF7FpejmJUfV4hf2yaf_0JlDpTAojB9_lOIX2Zq6I
 id: media.image.colorbox_square
 targetEntityType: media
 bundle: image

--- a/config/install/core.entity_view_mode.media.colorbox_small.yml
+++ b/config/install/core.entity_view_mode.media.colorbox_small.yml
@@ -1,4 +1,3 @@
-uuid: 2941c28c-a1da-4317-8419-d99bbee345b6
 langcode: en
 status: true
 dependencies:

--- a/config/install/core.entity_view_mode.media.colorbox_small_square.yml
+++ b/config/install/core.entity_view_mode.media.colorbox_small_square.yml
@@ -1,4 +1,3 @@
-uuid: a671f23e-9cdd-4453-8e4c-084c49b0da8d
 langcode: en
 status: true
 dependencies:

--- a/config/install/core.entity_view_mode.media.colorbox_small_thumbnail.yml
+++ b/config/install/core.entity_view_mode.media.colorbox_small_thumbnail.yml
@@ -1,4 +1,3 @@
-uuid: 8625db82-6342-468c-9c10-6cb571017794
 langcode: en
 status: true
 dependencies:

--- a/config/install/core.entity_view_mode.media.colorbox_square.yml
+++ b/config/install/core.entity_view_mode.media.colorbox_square.yml
@@ -1,4 +1,3 @@
-uuid: a1f845c8-c283-4836-bb7f-c37b7c4e5a60
 langcode: en
 status: true
 dependencies:

--- a/config/install/field.field.block_content.faculty_publications.field_bs_background_style.yml
+++ b/config/install/field.field.block_content.faculty_publications.field_bs_background_style.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.faculty_publications
+    - field.storage.block_content.field_bs_background_style
+  module:
+    - options
+id: block_content.faculty_publications.field_bs_background_style
+field_name: field_bs_background_style
+entity_type: block_content
+bundle: faculty_publications
+label: 'Background Style'
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: bs_background_style_none
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.field.block_content.faculty_publications.field_bs_content_font_scale.yml
+++ b/config/install/field.field.block_content.faculty_publications.field_bs_content_font_scale.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.faculty_publications
+    - field.storage.block_content.field_bs_content_font_scale
+  module:
+    - options
+id: block_content.faculty_publications.field_bs_content_font_scale
+field_name: field_bs_content_font_scale
+entity_type: block_content
+bundle: faculty_publications
+label: 'Content Font Scale'
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: bs_content_font_scale_default
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.field.block_content.faculty_publications.field_bs_heading.yml
+++ b/config/install/field.field.block_content.faculty_publications.field_bs_heading.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.faculty_publications
+    - field.storage.block_content.field_bs_heading
+  module:
+    - options
+id: block_content.faculty_publications.field_bs_heading
+field_name: field_bs_heading
+entity_type: block_content
+bundle: faculty_publications
+label: Heading
+description: 'This setting should be used to put your content in the proper hierarchy, not to change the font size of the title.'
+required: true
+translatable: false
+default_value:
+  -
+    value: bs_heading_default
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.field.block_content.faculty_publications.field_bs_heading_alignment.yml
+++ b/config/install/field.field.block_content.faculty_publications.field_bs_heading_alignment.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.faculty_publications
+    - field.storage.block_content.field_bs_heading_alignment
+  module:
+    - options
+id: block_content.faculty_publications.field_bs_heading_alignment
+field_name: field_bs_heading_alignment
+entity_type: block_content
+bundle: faculty_publications
+label: 'Heading Alignment'
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: bs_heading_align_default
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.field.block_content.faculty_publications.field_bs_heading_style.yml
+++ b/config/install/field.field.block_content.faculty_publications.field_bs_heading_style.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.faculty_publications
+    - field.storage.block_content.field_bs_heading_style
+  module:
+    - options
+id: block_content.faculty_publications.field_bs_heading_style
+field_name: field_bs_heading_style
+entity_type: block_content
+bundle: faculty_publications
+label: 'Heading Style'
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: bs_heading_style_default
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.field.block_content.faculty_publications.field_bs_icon.yml
+++ b/config/install/field.field.block_content.faculty_publications.field_bs_icon.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.faculty_publications
+    - field.storage.block_content.field_bs_icon
+    - filter.format.icon_picker
+  module:
+    - text
+id: block_content.faculty_publications.field_bs_icon
+field_name: field_bs_icon
+entity_type: block_content
+bundle: faculty_publications
+label: Icon
+description: 'Use the Icons button in the WYSIWYG bar to select your icon. Only the icon will be used. Styling will be applied with the settings below.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats:
+    - icon_picker
+field_type: text_long

--- a/config/install/field.field.block_content.faculty_publications.field_bs_icon.yml
+++ b/config/install/field.field.block_content.faculty_publications.field_bs_icon.yml
@@ -4,7 +4,6 @@ dependencies:
   config:
     - block_content.type.faculty_publications
     - field.storage.block_content.field_bs_icon
-    - filter.format.icon_picker
   module:
     - text
 id: block_content.faculty_publications.field_bs_icon

--- a/config/install/field.field.block_content.faculty_publications.field_bs_icon_color.yml
+++ b/config/install/field.field.block_content.faculty_publications.field_bs_icon_color.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.faculty_publications
+    - field.storage.block_content.field_bs_icon_color
+  module:
+    - options
+id: block_content.faculty_publications.field_bs_icon_color
+field_name: field_bs_icon_color
+entity_type: block_content
+bundle: faculty_publications
+label: 'Icon Color'
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: bs_icon_color_default
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.field.block_content.faculty_publications.field_bs_icon_position.yml
+++ b/config/install/field.field.block_content.faculty_publications.field_bs_icon_position.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.faculty_publications
+    - field.storage.block_content.field_bs_icon_position
+  module:
+    - options
+id: block_content.faculty_publications.field_bs_icon_position
+field_name: field_bs_icon_position
+entity_type: block_content
+bundle: faculty_publications
+label: 'Icon Position'
+description: 'Choose how the icon positions itself with the heading.'
+required: true
+translatable: false
+default_value:
+  -
+    value: bs_icon_position_default
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.field.block_content.faculty_publications.field_bs_icon_size.yml
+++ b/config/install/field.field.block_content.faculty_publications.field_bs_icon_size.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.faculty_publications
+    - field.storage.block_content.field_bs_icon_size
+  module:
+    - options
+id: block_content.faculty_publications.field_bs_icon_size
+field_name: field_bs_icon_size
+entity_type: block_content
+bundle: faculty_publications
+label: 'Icon Size'
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: bs_icon_size_default
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.field.block_content.faculty_publications.field_bs_title_font_scale.yml
+++ b/config/install/field.field.block_content.faculty_publications.field_bs_title_font_scale.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.faculty_publications
+    - field.storage.block_content.field_bs_title_font_scale
+  module:
+    - options
+id: block_content.faculty_publications.field_bs_title_font_scale
+field_name: field_bs_title_font_scale
+entity_type: block_content
+bundle: faculty_publications
+label: 'Title Font Scale'
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: bs_title_font_scale_default
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.field.block_content.faculty_publications.field_faculty_publications_auto.yml
+++ b/config/install/field.field.block_content.faculty_publications.field_faculty_publications_auto.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.faculty_publications
+    - field.storage.block_content.field_faculty_publications_auto
+id: block_content.faculty_publications.field_faculty_publications_auto
+field_name: field_faculty_publications_auto
+entity_type: block_content
+bundle: faculty_publications
+label: "If placed on a person page, use that person's email automatically"
+description: 'Automatically detects when this block is placed on a faculty member''s person page and uses their email as the faculty email. The faculty member''s primary email address must match the one on <a target="_blank" href="https://experts.colorado.edu/people">CU Experts</a> or no publications will be returned.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/install/field.field.block_content.faculty_publications.field_faculty_publications_count.yml
+++ b/config/install/field.field.block_content.faculty_publications.field_faculty_publications_count.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.faculty_publications
+    - field.storage.block_content.field_faculty_publications_count
+  module:
+    - options
+id: block_content.faculty_publications.field_faculty_publications_count
+field_name: field_faculty_publications_count
+entity_type: block_content
+bundle: faculty_publications
+label: 'Number of results'
+description: 'The maximum number of publications to display. If more exist, a user may load more by clicking the "more publications" button.'
+required: true
+translatable: false
+default_value:
+  -
+    value: 25
+default_value_callback: ''
+settings: {  }
+field_type: list_integer

--- a/config/install/field.field.block_content.faculty_publications.field_faculty_publications_dpt.yml
+++ b/config/install/field.field.block_content.faculty_publications.field_faculty_publications_dpt.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.faculty_publications
+    - field.storage.block_content.field_faculty_publications_dpt
+id: block_content.faculty_publications.field_faculty_publications_dpt
+field_name: field_faculty_publications_dpt
+entity_type: block_content
+bundle: faculty_publications
+label: Department
+description: 'University of Colorado Boulder department id or name as it appears on <a target="_blank" href="https://experts.colorado.edu/organizations">CU Experts</a>.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/install/field.field.block_content.faculty_publications.field_faculty_publications_email.yml
+++ b/config/install/field.field.block_content.faculty_publications.field_faculty_publications_email.yml
@@ -9,7 +9,7 @@ field_name: field_faculty_publications_email
 entity_type: block_content
 bundle: faculty_publications
 label: 'Faculty email'
-description: ''
+description: 'University of Colorado Boulder faculty email as it appears on <a target="_blank" href="https://experts.colorado.edu/people">CU Experts</a>.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/install/field.field.block_content.faculty_publications.field_faculty_publications_email.yml
+++ b/config/install/field.field.block_content.faculty_publications.field_faculty_publications_email.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.faculty_publications
+    - field.storage.block_content.field_faculty_publications_email
+id: block_content.faculty_publications.field_faculty_publications_email
+field_name: field_faculty_publications_email
+entity_type: block_content
+bundle: faculty_publications
+label: 'Faculty email'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: email

--- a/config/install/field.field.block_content.faculty_publications.field_faculty_publications_from.yml
+++ b/config/install/field.field.block_content.faculty_publications.field_faculty_publications_from.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.faculty_publications
+    - field.storage.block_content.field_faculty_publications_from
+  module:
+    - datetime
+id: block_content.faculty_publications.field_faculty_publications_from
+field_name: field_faculty_publications_from
+entity_type: block_content
+bundle: faculty_publications
+label: From
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/config/install/field.field.block_content.faculty_publications.field_faculty_publications_jt.yml
+++ b/config/install/field.field.block_content.faculty_publications.field_faculty_publications_jt.yml
@@ -10,7 +10,7 @@ field_name: field_faculty_publications_jt
 entity_type: block_content
 bundle: faculty_publications
 label: 'Job type'
-description: 'Choose one or more job type to include. All people with the corresponding job type will be included.'
+description: 'Choose one or more job types to include. All people with the corresponding job type will be included.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/install/field.field.block_content.faculty_publications.field_faculty_publications_jt.yml
+++ b/config/install/field.field.block_content.faculty_publications.field_faculty_publications_jt.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.faculty_publications
+    - field.storage.block_content.field_faculty_publications_jt
+    - taxonomy.vocabulary.ucb_person_job_type
+id: block_content.faculty_publications.field_faculty_publications_jt
+field_name: field_faculty_publications_jt
+entity_type: block_content
+bundle: faculty_publications
+label: 'Job type'
+description: 'Choose one or more job type to include. All people with the corresponding job type will be included.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      ucb_person_job_type: ucb_person_job_type
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.block_content.faculty_publications.field_faculty_publications_p.yml
+++ b/config/install/field.field.block_content.faculty_publications.field_faculty_publications_p.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.faculty_publications
+    - field.storage.block_content.field_faculty_publications_p
+    - node.type.ucb_person
+id: block_content.faculty_publications.field_faculty_publications_p
+field_name: field_faculty_publications_p
+entity_type: block_content
+bundle: faculty_publications
+label: People
+description: 'Choose one or more people to include.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      ucb_person: ucb_person
+    sort:
+      field: field_ucb_person_last_name
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.block_content.faculty_publications.field_faculty_publications_sort.yml
+++ b/config/install/field.field.block_content.faculty_publications.field_faculty_publications_sort.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.faculty_publications
+    - field.storage.block_content.field_faculty_publications_sort
+  module:
+    - options
+id: block_content.faculty_publications.field_faculty_publications_sort
+field_name: field_faculty_publications_sort
+entity_type: block_content
+bundle: faculty_publications
+label: Sort
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: date-desc
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.field.block_content.faculty_publications.field_faculty_publications_to.yml
+++ b/config/install/field.field.block_content.faculty_publications.field_faculty_publications_to.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.faculty_publications
+    - field.storage.block_content.field_faculty_publications_to
+  module:
+    - datetime
+id: block_content.faculty_publications.field_faculty_publications_to
+field_name: field_faculty_publications_to
+entity_type: block_content
+bundle: faculty_publications
+label: To
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/config/install/field.storage.block_content.field_faculty_publications_auto.yml
+++ b/config/install/field.storage.block_content.field_faculty_publications_auto.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_faculty_publications_auto
+field_name: field_faculty_publications_auto
+entity_type: block_content
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_faculty_publications_count.yml
+++ b/config/install/field.storage.block_content.field_faculty_publications_count.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - options
+id: block_content.field_faculty_publications_count
+field_name: field_faculty_publications_count
+entity_type: block_content
+type: list_integer
+settings:
+  allowed_values:
+    -
+      value: 10
+      label: '10'
+    -
+      value: 25
+      label: '25'
+    -
+      value: 50
+      label: '50'
+    -
+      value: 100
+      label: '100'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_faculty_publications_dpt.yml
+++ b/config/install/field.storage.block_content.field_faculty_publications_dpt.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_faculty_publications_dpt
+field_name: field_faculty_publications_dpt
+entity_type: block_content
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_faculty_publications_email.yml
+++ b/config/install/field.storage.block_content.field_faculty_publications_email.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_faculty_publications_email
+field_name: field_faculty_publications_email
+entity_type: block_content
+type: email
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_faculty_publications_from.yml
+++ b/config/install/field.storage.block_content.field_faculty_publications_from.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - datetime
+id: block_content.field_faculty_publications_from
+field_name: field_faculty_publications_from
+entity_type: block_content
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_faculty_publications_jt.yml
+++ b/config/install/field.storage.block_content.field_faculty_publications_jt.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - taxonomy
+id: block_content.field_faculty_publications_jt
+field_name: field_faculty_publications_jt
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_faculty_publications_p.yml
+++ b/config/install/field.storage.block_content.field_faculty_publications_p.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - node
+id: block_content.field_faculty_publications_p
+field_name: field_faculty_publications_p
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_faculty_publications_sort.yml
+++ b/config/install/field.storage.block_content.field_faculty_publications_sort.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - options
+id: block_content.field_faculty_publications_sort
+field_name: field_faculty_publications_sort
+entity_type: block_content
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: date-desc
+      label: 'Newest to oldest'
+    -
+      value: date-asc
+      label: 'Oldest to newest'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_faculty_publications_to.yml
+++ b/config/install/field.storage.block_content.field_faculty_publications_to.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - datetime
+id: block_content.field_faculty_publications_to
+field_name: field_faculty_publications_to
+entity_type: block_content
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/image.style.colorbox_small.yml
+++ b/config/install/image.style.colorbox_small.yml
@@ -1,4 +1,3 @@
-uuid: d24d4992-67bf-4ac1-9bf9-ee9a7d173f8f
 langcode: en
 status: true
 dependencies: {  }

--- a/config/install/image.style.colorbox_small_thumbnail.yml
+++ b/config/install/image.style.colorbox_small_thumbnail.yml
@@ -1,4 +1,3 @@
-uuid: 582e608b-1384-4fb0-b488-6dbf5996b8ad
 langcode: en
 status: true
 dependencies: {  }

--- a/config/install/image.style.slider_3_2.yml
+++ b/config/install/image.style.slider_3_2.yml
@@ -1,4 +1,3 @@
-uuid: d4e3cff8-6c37-4a7a-b711-d31a6d3d375e
 langcode: en
 status: true
 dependencies:

--- a/config/install/image.style.slider_ultrawide.yml
+++ b/config/install/image.style.slider_ultrawide.yml
@@ -1,4 +1,3 @@
-uuid: 9be1a3e6-bed7-4ddd-b409-76a16d57107a
 langcode: en
 status: true
 dependencies:

--- a/config/install/image.style.slider_widescreen.yml
+++ b/config/install/image.style.slider_widescreen.yml
@@ -1,4 +1,3 @@
-uuid: bca0077d-4b12-494a-ac61-5dd28d6172e8
 langcode: en
 status: true
 dependencies:


### PR DESCRIPTION
[new] This update adds the Faculty Publications block. Faculty Publications blocks pull results from [CU Experts](https://experts.colorado.edu/). A variety of filters are available to bring near feature-parity with the version in D7. Notable changes in this version:

- Adds an option to detect when the block has been added to a faculty member's person page, and automatically use that person's email address for the author filter.
- Replaces the pager with a "More publications" button which loads the next batch of publications. Results are loaded fast and no longer require a reload of the page to view.
- Removes "Any" for number of results to prevent poor client performance. 10, 25, 50, or 100 are available options.

CuBoulder/tiamat-theme#1146

Sister PR in: [tiamat-theme](https://github.com/CuBoulder/tiamat-theme/pull/1297), [tiamat10-profile](https://github.com/CuBoulder/tiamat10-profile/pull/201)