### PR TITLE
Article List Page: Expose Category/Tag Filter Toggle Setting

### DIFF
--- a/config/install/core.entity_form_display.node.ucb_article_list.default.yml
+++ b/config/install/core.entity_form_display.node.ucb_article_list.default.yml
@@ -5,6 +5,8 @@ dependencies:
     - field.field.node.ucb_article_list.body
     - field.field.node.ucb_article_list.field_ucb_exclude_category
     - field.field.node.ucb_article_list.field_ucb_exclude_tag
+    - field.field.node.ucb_article_list.field_ucb_expose_category
+    - field.field.node.ucb_article_list.field_ucb_expose_tag
     - field.field.node.ucb_article_list.field_ucb_filter_by_category
     - field.field.node.ucb_article_list.field_ucb_filter_by_tag
     - node.type.ucb_article_list
@@ -18,6 +20,7 @@ third_party_settings:
       children:
         - group_ucb_include_filter
         - group_ucb_exclude_filter
+        - group_ucb_expose_filters
       label: Filters
       region: content
       parent_name: ''
@@ -61,6 +64,23 @@ third_party_settings:
         formatter: closed
         description: ''
         required_fields: true
+    group_ucb_expose_filters:
+      children:
+        - field_ucb_expose_category
+        - field_ucb_expose_tag
+      label: 'Expose Filters'
+      region: content
+      parent_name: group_ucb_filters
+      weight: 15
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        formatter: closed
+        description: ''
+        required_fields: true
 id: node.ucb_article_list.default
 targetEntityType: node
 bundle: ucb_article_list
@@ -93,6 +113,20 @@ content:
     weight: 12
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_ucb_expose_category:
+    type: boolean_checkbox
+    weight: 16
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_ucb_expose_tag:
+    type: boolean_checkbox
+    weight: 17
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   field_ucb_filter_by_category:
     type: options_buttons

--- a/config/install/core.entity_view_display.node.ucb_article_list.default.yml
+++ b/config/install/core.entity_view_display.node.ucb_article_list.default.yml
@@ -5,6 +5,8 @@ dependencies:
     - field.field.node.ucb_article_list.body
     - field.field.node.ucb_article_list.field_ucb_exclude_category
     - field.field.node.ucb_article_list.field_ucb_exclude_tag
+    - field.field.node.ucb_article_list.field_ucb_expose_category
+    - field.field.node.ucb_article_list.field_ucb_expose_tag
     - field.field.node.ucb_article_list.field_ucb_filter_by_category
     - field.field.node.ucb_article_list.field_ucb_filter_by_tag
     - node.type.ucb_article_list
@@ -36,6 +38,26 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 105
+    region: content
+  field_ucb_expose_category:
+    type: boolean
+    label: hidden
+    settings:
+      format: true-false
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 106
+    region: content
+  field_ucb_expose_tag:
+    type: boolean
+    label: hidden
+    settings:
+      format: true-false
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 107
     region: content
   field_ucb_filter_by_category:
     type: entity_reference_entity_id

--- a/config/install/core.entity_view_display.node.ucb_article_list.teaser.yml
+++ b/config/install/core.entity_view_display.node.ucb_article_list.teaser.yml
@@ -6,6 +6,8 @@ dependencies:
     - field.field.node.ucb_article_list.body
     - field.field.node.ucb_article_list.field_ucb_exclude_category
     - field.field.node.ucb_article_list.field_ucb_exclude_tag
+    - field.field.node.ucb_article_list.field_ucb_expose_category
+    - field.field.node.ucb_article_list.field_ucb_expose_tag
     - field.field.node.ucb_article_list.field_ucb_filter_by_category
     - field.field.node.ucb_article_list.field_ucb_filter_by_tag
     - node.type.ucb_article_list
@@ -33,5 +35,7 @@ content:
 hidden:
   field_ucb_exclude_category: true
   field_ucb_exclude_tag: true
+  field_ucb_expose_category: true
+  field_ucb_expose_tag: true
   field_ucb_filter_by_category: true
   field_ucb_filter_by_tag: true

--- a/config/install/field.field.node.ucb_article_list.field_ucb_expose_category.yml
+++ b/config/install/field.field.node.ucb_article_list.field_ucb_expose_category.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_expose_category
+    - node.type.ucb_article_list
+id: node.ucb_article_list.field_ucb_expose_category
+field_name: field_ucb_expose_category
+entity_type: node
+bundle: ucb_article_list
+label: 'Show Category Filter'
+description: 'Allow visitors to filter on Categories'
+required: true
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: Show
+  off_label: Hide
+field_type: boolean

--- a/config/install/field.field.node.ucb_article_list.field_ucb_expose_category.yml
+++ b/config/install/field.field.node.ucb_article_list.field_ucb_expose_category.yml
@@ -10,7 +10,7 @@ entity_type: node
 bundle: ucb_article_list
 label: 'Show Category Filter'
 description: 'Allow visitors to filter on Categories'
-required: true
+required: false
 translatable: false
 default_value:
   -

--- a/config/install/field.field.node.ucb_article_list.field_ucb_expose_tag.yml
+++ b/config/install/field.field.node.ucb_article_list.field_ucb_expose_tag.yml
@@ -10,7 +10,7 @@ entity_type: node
 bundle: ucb_article_list
 label: 'Show Tag Filter'
 description: 'Allow visitors to filter on Tags'
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/install/field.field.node.ucb_article_list.field_ucb_expose_tag.yml
+++ b/config/install/field.field.node.ucb_article_list.field_ucb_expose_tag.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_expose_tag
+    - node.type.ucb_article_list
+id: node.ucb_article_list.field_ucb_expose_tag
+field_name: field_ucb_expose_tag
+entity_type: node
+bundle: ucb_article_list
+label: 'Show Tag Filter'
+description: 'Allow visitors to filter on Tags'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: Show
+  off_label: Hide
+field_type: boolean

--- a/config/install/field.storage.node.field_ucb_expose_category.yml
+++ b/config/install/field.storage.node.field_ucb_expose_category.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_ucb_expose_category
+field_name: field_ucb_expose_category
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_ucb_expose_tag.yml
+++ b/config/install/field.storage.node.field_ucb_expose_tag.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_ucb_expose_tag
+field_name: field_ucb_expose_tag
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
Adds two new toggles to the Article List Page settings, which will expose filters on Categories and Tags for page visitors. This will allow visitors to the page to further filter Articles, which was previously a setting in D7.

This will have migration implications. 

Includes:
- `tiamat-theme` => https://github.com/CuBoulder/tiamat-theme/pull/1387
- `tiamat-custom-entities` => https://github.com/CuBoulder/tiamat-custom-entities/pull/180

Resolves https://github.com/CuBoulder/tiamat-theme/pull/1387