### PR TITLE
Additional height options for video hero unit

### DIFF
--- a/config/install/core.entity_form_display.block_content.video_hero_unit.default.yml
+++ b/config/install/core.entity_form_display.block_content.video_hero_unit.default.yml
@@ -15,7 +15,9 @@ dependencies:
     - field.field.block_content.video_hero_unit.field_bs_title_font_scale
     - field.field.block_content.video_hero_unit.field_headline
     - field.field.block_content.video_hero_unit.field_hero_background_video
+    - field.field.block_content.video_hero_unit.field_hero_bottom_padding
     - field.field.block_content.video_hero_unit.field_hero_overlay
+    - field.field.block_content.video_hero_unit.field_hero_top_padding
     - field.field.block_content.video_hero_unit.field_link_color
     - field.field.block_content.video_hero_unit.field_links
     - field.field.block_content.video_hero_unit.field_size
@@ -70,6 +72,8 @@ third_party_settings:
         - field_text_color
         - field_link_color
         - field_hero_overlay
+        - field_hero_top_padding
+        - field_hero_bottom_padding
       label: Design
       region: content
       parent_name: group_video_hero_unit_tabs
@@ -248,12 +252,26 @@ content:
     settings:
       media_types: {  }
     third_party_settings: {  }
+  field_hero_bottom_padding:
+    type: number
+    weight: 9
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
   field_hero_overlay:
     type: boolean_checkbox
     weight: 7
     region: content
     settings:
       display_label: true
+    third_party_settings: {  }
+  field_hero_top_padding:
+    type: number
+    weight: 8
+    region: content
+    settings:
+      placeholder: ''
     third_party_settings: {  }
   field_link_color:
     type: options_select

--- a/config/install/core.entity_view_display.block_content.video_hero_unit.default.yml
+++ b/config/install/core.entity_view_display.block_content.video_hero_unit.default.yml
@@ -15,7 +15,9 @@ dependencies:
     - field.field.block_content.video_hero_unit.field_bs_title_font_scale
     - field.field.block_content.video_hero_unit.field_headline
     - field.field.block_content.video_hero_unit.field_hero_background_video
+    - field.field.block_content.video_hero_unit.field_hero_bottom_padding
     - field.field.block_content.video_hero_unit.field_hero_overlay
+    - field.field.block_content.video_hero_unit.field_hero_top_padding
     - field.field.block_content.video_hero_unit.field_link_color
     - field.field.block_content.video_hero_unit.field_links
     - field.field.block_content.video_hero_unit.field_size
@@ -108,6 +110,24 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_hero_bottom_padding:
+    type: number_integer
+    label: hidden
+    settings:
+      thousand_separator: ''
+      prefix_suffix: false
+    third_party_settings: {  }
+    weight: 14
+    region: content
+  field_hero_top_padding:
+    type: number_integer
+    label: hidden
+    settings:
+      thousand_separator: ''
+      prefix_suffix: false
+    third_party_settings: {  }
+    weight: 13
     region: content
   field_links:
     type: link

--- a/config/install/field.field.block_content.video_hero_unit.field_hero_bottom_padding.yml
+++ b/config/install/field.field.block_content.video_hero_unit.field_hero_bottom_padding.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.video_hero_unit
+    - field.storage.block_content.field_hero_bottom_padding
+id: block_content.video_hero_unit.field_hero_bottom_padding
+field_name: field_hero_bottom_padding
+entity_type: block_content
+bundle: video_hero_unit
+label: "Bottom Padding\t"
+description: 'Set number of pixels to extend the bottom padding by. Used for adjusting video height.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 100
+default_value_callback: ''
+settings:
+  min: 0
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/install/field.field.block_content.video_hero_unit.field_hero_top_padding.yml
+++ b/config/install/field.field.block_content.video_hero_unit.field_hero_top_padding.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.video_hero_unit
+    - field.storage.block_content.field_hero_top_padding
+id: block_content.video_hero_unit.field_hero_top_padding
+field_name: field_hero_top_padding
+entity_type: block_content
+bundle: video_hero_unit
+label: 'Top Padding'
+description: 'Set number of pixels to extend the top padding by. Used for adjusting video height.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 100
+default_value_callback: ''
+settings:
+  min: 0
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/install/field.storage.block_content.field_hero_bottom_padding.yml
+++ b/config/install/field.storage.block_content.field_hero_bottom_padding.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_hero_bottom_padding
+field_name: field_hero_bottom_padding
+entity_type: block_content
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_hero_top_padding.yml
+++ b/config/install/field.storage.block_content.field_hero_top_padding.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_hero_top_padding
+field_name: field_hero_top_padding
+entity_type: block_content
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
Added top and bottom padding options to the design tab so that users can easily adjust the height of their videos.

Sister PR: https://github.com/CuBoulder/tiamat-theme/pull/1480