### PR TITLE
Updates Description of Summary/Thumbnail section of Articles

### DIFF
--- a/config/install/core.entity_form_display.node.ucb_article.default.yml
+++ b/config/install/core.entity_form_display.node.ucb_article.default.yml
@@ -65,7 +65,7 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         formatter: closed
-        description: 'These items will show in the summary instead of the main content.'
+        description: 'Summary and Thumbnail are used in Article List pages and blocks, and also power social sharing previews on platforms like Facebook, X (Twitter), and Teams. Fill these out to ensure your content looks great when shared.'
         required_fields: true
     group_categories:
       children:


### PR DESCRIPTION
Helps clarify the purpose of the Summary and Thumbnail fields on Article nodes, since they will be used for aggregator blocks like the Article List, and in metatags to facilitate social sharing across applications. 

Includes: 
- `profile` => https://github.com/CuBoulder/tiamat10-profile/pull/280
- `custom_entities` => https://github.com/CuBoulder/tiamat-custom-entities/pull/210

Resolves https://github.com/CuBoulder/tiamat10-profile/issues/279