### PR TITLE
Adds Syndicated CU content block

### DIFF
--- a/config/install/block_content.type.ucb_trusted_content_block.yml
+++ b/config/install/block_content.type.ucb_trusted_content_block.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: ucb_trusted_content_block
+label: 'Trusted CU Content'
+revision: false
+description: 'Allows your site to display and share syndicated Articles, People Pages, and Basic Pages from other Trusted CU partner sites'

--- a/config/install/block_content.type.ucb_trusted_content_block.yml
+++ b/config/install/block_content.type.ucb_trusted_content_block.yml
@@ -2,6 +2,6 @@ langcode: en
 status: true
 dependencies: {  }
 id: ucb_trusted_content_block
-label: 'Trusted CU Content'
+label: 'Syndicated CU Content'
 revision: false
 description: 'Allows your site to display and share syndicated Articles, People Pages, and Basic Pages from other Trusted CU partner sites'

--- a/config/install/core.entity_form_display.block_content.ucb_trusted_content_block.default.yml
+++ b/config/install/core.entity_form_display.block_content.ucb_trusted_content_block.default.yml
@@ -1,0 +1,48 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_trusted_content_block
+    - field.field.block_content.ucb_trusted_content_block.body
+    - field.field.block_content.ucb_trusted_content_block.field_trusted_content_display
+    - field.field.block_content.ucb_trusted_content_block.field_trusted_content_link
+  module:
+    - text
+id: block_content.ucb_trusted_content_block.default
+targetEntityType: block_content
+bundle: ucb_trusted_content_block
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 26
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+  field_trusted_content_display:
+    type: options_select
+    weight: 27
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_trusted_content_link:
+    type: string_textarea
+    weight: 28
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  info:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/config/install/core.entity_view_display.block_content.ucb_trusted_content_block.default.yml
+++ b/config/install/core.entity_view_display.block_content.ucb_trusted_content_block.default.yml
@@ -1,0 +1,38 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_trusted_content_block
+    - field.field.block_content.ucb_trusted_content_block.body
+    - field.field.block_content.ucb_trusted_content_block.field_trusted_content_display
+    - field.field.block_content.ucb_trusted_content_block.field_trusted_content_link
+  module:
+    - options
+    - text
+id: block_content.ucb_trusted_content_block.default
+targetEntityType: block_content
+bundle: ucb_trusted_content_block
+mode: default
+content:
+  body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_trusted_content_display:
+    type: list_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_trusted_content_link:
+    type: basic_string
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+hidden: {  }

--- a/config/install/field.field.block_content.ucb_trusted_content_block.body.yml
+++ b/config/install/field.field.block_content.ucb_trusted_content_block.body.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_trusted_content_block
+    - field.storage.block_content.body
+  module:
+    - text
+id: block_content.ucb_trusted_content_block.body
+field_name: body
+entity_type: block_content
+bundle: ucb_trusted_content_block
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+  required_summary: false
+  allowed_formats: {  }
+field_type: text_with_summary

--- a/config/install/field.field.block_content.ucb_trusted_content_block.field_trusted_content_display.yml
+++ b/config/install/field.field.block_content.ucb_trusted_content_block.field_trusted_content_display.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_trusted_content_block
+    - field.storage.block_content.field_trusted_content_display
+  module:
+    - options
+id: block_content.ucb_trusted_content_block.field_trusted_content_display
+field_name: field_trusted_content_display
+entity_type: block_content
+bundle: ucb_trusted_content_block
+label: Display
+description: 'Choose how your content displays'
+required: true
+translatable: false
+default_value:
+  -
+    value: teaser
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.field.block_content.ucb_trusted_content_block.field_trusted_content_link.yml
+++ b/config/install/field.field.block_content.ucb_trusted_content_block.field_trusted_content_link.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.ucb_trusted_content_block
+    - field.storage.block_content.field_trusted_content_link
+id: block_content.ucb_trusted_content_block.field_trusted_content_link
+field_name: field_trusted_content_link
+entity_type: block_content
+bundle: ucb_trusted_content_block
+label: 'Content Link'
+description: 'Paste the link provided from the Discovery site here to link to the syndicated content'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/install/field.storage.block_content.field_trusted_content_display.yml
+++ b/config/install/field.storage.block_content.field_trusted_content_display.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - options
+id: block_content.field_trusted_content_display
+field_name: field_trusted_content_display
+entity_type: block_content
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: teaser
+      label: Teaser
+    -
+      value: feature
+      label: Feature
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.block_content.field_trusted_content_link.yml
+++ b/config/install/field.storage.block_content.field_trusted_content_link.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_trusted_content_link
+field_name: field_trusted_content_link
+entity_type: block_content
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
Adds the Syndicated CU Content block to allow `Trust => Discovery => Consumer site` content sharing pipeline